### PR TITLE
chore: deprecate methods that explicitly set shard and real to 0, adjust code so it doesn't uses them

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ClientHelper.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ClientHelper.java
@@ -14,7 +14,7 @@ public class ClientHelper {
 
     private static final String LOCAL_MIRROR_NODE_GRPC_ENDPOINT = "127.0.0.1:5600";
 
-    private static final AccountId LOCAL_CONSENSUS_NODE_ACCOUNT_ID = new AccountId(3);
+    private static final AccountId LOCAL_CONSENSUS_NODE_ACCOUNT_ID = new AccountId(0, 0, 3);
 
     public static Client forName(String network) throws InterruptedException {
         Client client;

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConstructClientExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConstructClientExample.java
@@ -74,8 +74,8 @@ class ConstructClientExample {
 
         // Let's create a client with a custom network.
         Map<String, AccountId> customNetwork = new HashMap<>();
-        customNetwork.put("2.testnet.hedera.com:50211", new AccountId(5));
-        customNetwork.put("3.testnet.hedera.com:50211", new AccountId(6));
+        customNetwork.put("2.testnet.hedera.com:50211", new AccountId(0, 0, 5));
+        customNetwork.put("3.testnet.hedera.com:50211", new AccountId(0, 0, 6));
         Client customClient = Client.forNetwork(customNetwork);
 
         /*

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/CreateAccountThresholdKeyExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/CreateAccountThresholdKeyExample.java
@@ -111,7 +111,7 @@ class CreateAccountThresholdKeyExample {
         System.out.println("Transferring 1 Hbar from a newly created account...");
         TransactionResponse transferTxResponse = new TransferTransaction()
                 .addHbarTransfer(newAccountId, Hbar.from(1).negated())
-                .addHbarTransfer(new AccountId(3), Hbar.from(1))
+                .addHbarTransfer(new AccountId(0, 0, 3), Hbar.from(1))
                 // To manually sign, you must explicitly build the Transaction.
                 .freezeWith(client)
                 // We sign with 2 of the 3 keys.

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/MultiSigOfflineExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/MultiSigOfflineExample.java
@@ -105,11 +105,11 @@ class MultiSigOfflineExample {
          */
         System.out.println("Transferring 1 Hbar from new account to the account with ID `0.0.3`...");
         TransferTransaction transferTx = new TransferTransaction()
-                .setNodeAccountIds(Collections.singletonList(new AccountId(3)))
+                .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 3)))
                 .addHbarTransfer(
                         Objects.requireNonNull(createAccountTxReceipt.accountId),
                         Hbar.from(1).negated())
-                .addHbarTransfer(new AccountId(3), Hbar.from(1))
+                .addHbarTransfer(new AccountId(0, 0, 3), Hbar.from(1))
                 .freezeWith(client);
 
         /*

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ScheduleMultiSigTransactionExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ScheduleMultiSigTransactionExample.java
@@ -95,7 +95,7 @@ class ScheduleMultiSigTransactionExample {
          */
         System.out.println("Creating new account...");
         TransactionResponse accountCreateTxResponse = new AccountCreateTransaction()
-                .setNodeAccountIds(Collections.singletonList(new AccountId(3)))
+                .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 3)))
                 // The only required property here is key.
                 .setKeyWithoutAlias(keyList)
                 .setInitialBalance(Hbar.from(2))

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/SignTransactionExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/SignTransactionExample.java
@@ -100,11 +100,11 @@ class SignTransactionExample {
          */
         System.out.println("Creating a transfer transaction...");
         TransferTransaction transferTx = new TransferTransaction()
-                .setNodeAccountIds(Collections.singletonList(new AccountId(3)))
+                .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 3)))
                 .addHbarTransfer(
                         Objects.requireNonNull(createAccountTxReceipt.accountId),
                         Hbar.from(1).negated())
-                .addHbarTransfer(new AccountId(3), Hbar.from(1))
+                .addHbarTransfer(new AccountId(0, 0, 3), Hbar.from(1))
                 .freezeWith(client);
 
         /*

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -57,6 +57,9 @@ public final class AccountId implements Comparable<AccountId> {
      * Assign the num part of the account id.
      *
      * @param num                       the num part of the account id
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public AccountId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -58,6 +58,7 @@ public final class AccountId implements Comparable<AccountId> {
      *
      * @param num                       the num part of the account id
      */
+    @Deprecated
     public AccountId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
@@ -394,7 +394,7 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
      */
     public AccountUpdateTransaction clearStakedAccountId() {
         requireNotFrozen();
-        this.stakedAccountId = new AccountId(0);
+        this.stakedAccountId = new AccountId(0, 0, 0);
         this.stakedNodeId = null;
         return this;
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -50,6 +50,7 @@ public class ContractId extends Key implements Comparable<ContractId> {
      *
      * @param num                       the num part of the account id
      */
+    @Deprecated
     public ContractId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -49,6 +49,9 @@ public class ContractId extends Key implements Comparable<ContractId> {
      * Assign the num part of the contract id.
      *
      * @param num                       the num part of the account id
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public ContractId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractUpdateTransaction.java
@@ -371,7 +371,7 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      */
     public ContractUpdateTransaction clearStakedAccountId() {
         requireNotFrozen();
-        this.stakedAccountId = new AccountId(0);
+        this.stakedAccountId = new AccountId(0, 0, 0);
         this.stakedNodeId = null;
         return this;
     }
@@ -501,7 +501,7 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @return {@code this}
      */
     public ContractUpdateTransaction clearAutoRenewAccountId() {
-        this.autoRenewAccountId = new AccountId(0);
+        this.autoRenewAccountId = new AccountId(0, 0, 0);
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/DelegateContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/DelegateContractId.java
@@ -15,6 +15,7 @@ public final class DelegateContractId extends ContractId {
      *
      * @param num                       the num portion of the contract id
      */
+    @Deprecated
     public DelegateContractId(long num) {
         super(num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/DelegateContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/DelegateContractId.java
@@ -14,6 +14,9 @@ public final class DelegateContractId extends ContractId {
      * Constructor.
      *
      * @param num                       the num portion of the contract id
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public DelegateContractId(long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
@@ -47,6 +47,7 @@ public final class FileId implements Comparable<FileId> {
      *
      * @param num                       the num portion not negative
      */
+    @Deprecated
     public FileId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
@@ -46,6 +46,9 @@ public final class FileId implements Comparable<FileId> {
      * Assign the num portion of the file id.
      *
      * @param num                       the num portion not negative
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public FileId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Query.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Query.java
@@ -526,8 +526,8 @@ public abstract class Query<O, T extends Query<O, T>>
             // now go back to sleep
             // without this, an error of MISSING_QUERY_HEADER is returned
             headerBuilder.setPayment(new TransferTransaction()
-                    .setNodeAccountIds(Collections.singletonList(new AccountId(0)))
-                    .setTransactionId(TransactionId.withValidStart(new AccountId(0), Instant.ofEpochSecond(0)))
+                    .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 0)))
+                    .setTransactionId(TransactionId.withValidStart(new AccountId(0, 0, 0), Instant.ofEpochSecond(0)))
                     .freeze()
                     .makeRequest());
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleId.java
@@ -39,6 +39,7 @@ public final class ScheduleId implements Comparable<ScheduleId> {
      *
      * @param num                       the num part
      */
+    @Deprecated
     public ScheduleId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleId.java
@@ -38,6 +38,9 @@ public final class ScheduleId implements Comparable<ScheduleId> {
      * Constructor.
      *
      * @param num                       the num part
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public ScheduleId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenId.java
@@ -38,6 +38,9 @@ public class TokenId implements Comparable<TokenId> {
      * Constructor.
      *
      * @param num                       the num part
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public TokenId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenId.java
@@ -39,6 +39,7 @@ public class TokenId implements Comparable<TokenId> {
      *
      * @param num                       the num part
      */
+    @Deprecated
     public TokenId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicId.java
@@ -37,6 +37,7 @@ public final class TopicId implements Comparable<TopicId> {
      *
      * @param num                       the num part
      */
+    @Deprecated
     public TopicId(@Nonnegative long num) {
         this(0, 0, num);
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicId.java
@@ -36,6 +36,9 @@ public final class TopicId implements Comparable<TopicId> {
      * Constructor.
      *
      * @param num                       the num part
+     *
+     * Constructor that uses shard, realm and num should be used instead
+     * as shard and realm should not assume 0 value
      */
     @Deprecated
     public TopicId(@Nonnegative long num) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicUpdateTransaction.java
@@ -312,7 +312,7 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
      */
     public TopicUpdateTransaction clearAutoRenewAccountId() {
         requireNotFrozen();
-        autoRenewAccountId = new AccountId(0);
+        autoRenewAccountId = new AccountId(0, 0, 0);
         return this;
     }
 
@@ -548,7 +548,7 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
             topicId.validateChecksum(client);
         }
 
-        if ((autoRenewAccountId != null) && !autoRenewAccountId.equals(new AccountId(0))) {
+        if ((autoRenewAccountId != null) && !autoRenewAccountId.equals(new AccountId(0, 0, 0))) {
             autoRenewAccountId.validateChecksum(client);
         }
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -208,7 +208,7 @@ public abstract class Transaction<T extends Transaction<T>>
                 }
             }
 
-            nodeAccountIds.remove(new AccountId(0));
+            nodeAccountIds.remove(new AccountId(0, 0, 0));
 
             // Verify that transaction bodies match
             for (int i = 0; i < txCount; i++) {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountIdTest.java
@@ -155,7 +155,8 @@ class AccountIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new AccountId(5005).toProtobuf().toByteArray()))
+        SnapshotMatcher.expect(
+                        Hex.toHexString(new AccountId(0, 0, 5005).toProtobuf().toByteArray()))
                 .toMatchSnapshot();
     }
 
@@ -177,13 +178,13 @@ class AccountIdTest {
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
         SnapshotMatcher.expect(
-                        AccountId.fromBytes(new AccountId(5005).toBytes()).toString())
+                        AccountId.fromBytes(new AccountId(0, 0, 5005).toBytes()).toString())
                 .toMatchSnapshot();
     }
 
     @Test
     void toFromProtobuf() {
-        var id1 = new AccountId(5005);
+        var id1 = new AccountId(0, 0, 5005);
         var id2 = AccountId.fromProtobuf(id1.toProtobuf());
         assertThat(id2).isEqualTo(id1);
     }
@@ -237,7 +238,7 @@ class AccountIdTest {
 
     @Test
     void toSolidityAddress() {
-        SnapshotMatcher.expect(new AccountId(5005).toSolidityAddress()).toMatchSnapshot();
+        SnapshotMatcher.expect(new AccountId(0, 0, 5005).toSolidityAddress()).toMatchSnapshot();
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoTest.java
@@ -18,13 +18,13 @@ public class AccountInfoTest {
             "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
     private static final byte[] hash = {0, 1, 2};
     private static final LiveHash liveHash = LiveHash.newBuilder()
-            .setAccountId(new AccountId(10).toProtobuf())
+            .setAccountId(new AccountId(0, 0, 10).toProtobuf())
             .setDuration(DurationConverter.toProtobuf(Duration.ofDays(11)))
             .setHash(ByteString.copyFrom(hash))
             .setKeys(KeyList.newBuilder().addKeys(privateKey.getPublicKey().toProtobufKey()))
             .build();
     private static final CryptoGetInfoResponse.AccountInfo info = CryptoGetInfoResponse.AccountInfo.newBuilder()
-            .setAccountID(new AccountId(1).toProtobuf())
+            .setAccountID(new AccountId(0, 0, 1).toProtobuf())
             .setDeleted(true)
             .setProxyReceived(2)
             .setKey(privateKey.getPublicKey().toProtobufKey())
@@ -34,7 +34,7 @@ public class AccountInfoTest {
             .setReceiverSigRequired(true)
             .setExpirationTime(InstantConverter.toProtobuf(Instant.ofEpochMilli(6)))
             .setAutoRenewPeriod(DurationConverter.toProtobuf(Duration.ofDays(7)))
-            .setProxyAccountID(new AccountId(8).toProtobuf())
+            .setProxyAccountID(new AccountId(0, 0, 8).toProtobuf())
             .addLiveHashes(liveHash)
             .setLedgerId(LedgerId.PREVIEWNET.toByteString())
             .setEthereumNonce(1001)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
@@ -192,8 +192,8 @@ class ClientTest {
     @DisplayName("setNetwork() functions correctly")
     void setNetworkWorks() throws Exception {
         var defaultNetwork = Map.of(
-                "0.testnet.hedera.com:50211", new AccountId(3),
-                "1.testnet.hedera.com:50211", new AccountId(4));
+                "0.testnet.hedera.com:50211", new AccountId(0, 0, 3),
+                "1.testnet.hedera.com:50211", new AccountId(0, 0, 4));
 
         Client client = Client.forNetwork(defaultNetwork);
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(defaultNetwork);
@@ -202,32 +202,32 @@ class ClientTest {
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(defaultNetwork);
 
         var defaultNetworkWithExtraNode = Map.of(
-                "0.testnet.hedera.com:50211", new AccountId(3),
-                "1.testnet.hedera.com:50211", new AccountId(4),
-                "2.testnet.hedera.com:50211", new AccountId(5));
+                "0.testnet.hedera.com:50211", new AccountId(0, 0, 3),
+                "1.testnet.hedera.com:50211", new AccountId(0, 0, 4),
+                "2.testnet.hedera.com:50211", new AccountId(0, 0, 5));
 
         client.setNetwork(defaultNetworkWithExtraNode);
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(defaultNetworkWithExtraNode);
 
-        var singleNodeNetwork = Map.of("2.testnet.hedera.com:50211", new AccountId(5));
+        var singleNodeNetwork = Map.of("2.testnet.hedera.com:50211", new AccountId(0, 0, 5));
 
         client.setNetwork(singleNodeNetwork);
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(singleNodeNetwork);
 
-        var singleNodeNetworkWithDifferentAccountId = Map.of("2.testnet.hedera.com:50211", new AccountId(6));
+        var singleNodeNetworkWithDifferentAccountId = Map.of("2.testnet.hedera.com:50211", new AccountId(0, 0, 6));
 
         client.setNetwork(singleNodeNetworkWithDifferentAccountId);
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(singleNodeNetworkWithDifferentAccountId);
 
         var multiAddressNetwork = Map.of(
-                "0.testnet.hedera.com:50211", new AccountId(3),
-                "34.94.106.61:50211", new AccountId(3),
-                "50.18.132.211:50211", new AccountId(3),
-                "138.91.142.219:50211", new AccountId(3),
-                "1.testnet.hedera.com:50211", new AccountId(4),
-                "35.237.119.55:50211", new AccountId(4),
-                "3.212.6.13:50211", new AccountId(4),
-                "52.168.76.241:50211", new AccountId(4));
+                "0.testnet.hedera.com:50211", new AccountId(0, 0, 3),
+                "34.94.106.61:50211", new AccountId(0, 0, 3),
+                "50.18.132.211:50211", new AccountId(0, 0, 3),
+                "138.91.142.219:50211", new AccountId(0, 0, 3),
+                "1.testnet.hedera.com:50211", new AccountId(0, 0, 4),
+                "35.237.119.55:50211", new AccountId(0, 0, 4),
+                "3.212.6.13:50211", new AccountId(0, 0, 4),
+                "52.168.76.241:50211", new AccountId(0, 0, 4));
 
         client.setNetwork(multiAddressNetwork);
         assertThat(client.getNetwork()).containsExactlyInAnyOrderEntriesOf(multiAddressNetwork);
@@ -394,8 +394,11 @@ class ClientTest {
     @DisplayName("setNetworkFromAddressBook() updates security parameters in the client")
     void setNetworkFromAddressBook() throws Exception {
         try (Client client = Client.forNetwork(Map.of())) {
-            Function<Integer, NodeAddress> nodeAddress = accountNum ->
-                    client.network.network.get(new AccountId(accountNum)).get(0).getAddressBookEntry();
+            Function<Integer, NodeAddress> nodeAddress = accountNum -> client.network
+                    .network
+                    .get(new AccountId(0, 0, accountNum))
+                    .get(0)
+                    .getAddressBookEntry();
 
             // reconfigure client network from addressbook (add new nodes)
             client.setNetworkFromAddressBook(

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCreateTransactionTest.java
@@ -60,7 +60,7 @@ public class ContractCreateTransactionTest {
                 .setAutoRenewPeriod(Duration.ofHours(10))
                 .setConstructorParameters(new byte[] {10, 11, 12, 13, 25})
                 .setMaxTransactionFee(Hbar.fromTinybars(100_000))
-                .setAutoRenewAccountId(new AccountId(30))
+                .setAutoRenewAccountId(new AccountId(0, 0, 30))
                 .freeze()
                 .sign(unusedPrivateKey);
     }
@@ -78,7 +78,7 @@ public class ContractCreateTransactionTest {
                 .setAutoRenewPeriod(Duration.ofHours(10))
                 .setConstructorParameters(new byte[] {10, 11, 12, 13, 25})
                 .setMaxTransactionFee(Hbar.fromTinybars(100_000))
-                .setAutoRenewAccountId(new AccountId(30))
+                .setAutoRenewAccountId(new AccountId(0, 0, 30))
                 .freeze()
                 .sign(unusedPrivateKey);
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractDeleteTransactionTest.java
@@ -38,7 +38,7 @@ public class ContractDeleteTransactionTest {
                 .setNodeAccountIds(Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
                 .setTransactionId(TransactionId.withValidStart(AccountId.fromString("0.0.5006"), validStart))
                 .setContractId(ContractId.fromString("0.0.5007"))
-                .setTransferAccountId(new AccountId(9))
+                .setTransferAccountId(new AccountId(0, 0, 9))
                 .setTransferContractId(ContractId.fromString("0.0.5008"))
                 .setMaxTransactionFee(Hbar.fromTinybars(100_000))
                 .freeze()

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractIdTest.java
@@ -71,19 +71,20 @@ class ContractIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new ContractId(5005).toBytes())).toMatchSnapshot();
+        SnapshotMatcher.expect(Hex.toHexString(new ContractId(0, 0, 5005).toBytes()))
+                .toMatchSnapshot();
     }
 
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(
-                        ContractId.fromBytes(new ContractId(5005).toBytes()).toString())
+        SnapshotMatcher.expect(ContractId.fromBytes(new ContractId(0, 0, 5005).toBytes())
+                        .toString())
                 .toMatchSnapshot();
     }
 
     @Test
     void toSolidityAddress() {
-        SnapshotMatcher.expect(new ContractId(5005).toSolidityAddress()).toMatchSnapshot();
+        SnapshotMatcher.expect(new ContractId(0, 0, 5005).toSolidityAddress()).toMatchSnapshot();
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 
 public class ContractInfoTest {
     private final ContractGetInfoResponse.ContractInfo info = ContractGetInfoResponse.ContractInfo.newBuilder()
-            .setContractID(new ContractId(1).toProtobuf())
-            .setAccountID(new AccountId(2).toProtobuf())
+            .setContractID(new ContractId(0, 0, 1).toProtobuf())
+            .setAccountID(new AccountId(0, 0, 2).toProtobuf())
             .setContractAccountID("3")
             .setExpirationTime(InstantConverter.toProtobuf(Instant.ofEpochMilli(4)))
             .setAutoRenewPeriod(DurationConverter.toProtobuf(Duration.ofDays(5)))

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractLogInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractLogInfoTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 public class ContractLogInfoTest {
     private static final ContractLoginfo info = ContractLoginfo.newBuilder()
-            .setContractID(new ContractId(10).toProtobuf())
+            .setContractID(new ContractId(0, 0, 10).toProtobuf())
             .setBloom(ByteString.copyFrom("bloom", StandardCharsets.UTF_8))
             .addTopic(ByteString.copyFrom("bloom", StandardCharsets.UTF_8))
             .setData(ByteString.copyFrom("data", StandardCharsets.UTF_8))

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 public class ContractNonceInfoTest {
     private final com.hedera.hashgraph.sdk.proto.ContractNonceInfo info =
             com.hedera.hashgraph.sdk.proto.ContractNonceInfo.newBuilder()
-                    .setContractId(new ContractId(1).toProtobuf())
+                    .setContractId(new ContractId(0, 0, 1).toProtobuf())
                     .setNonce(2)
                     .build();
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractUpdateTransactionTest.java
@@ -57,9 +57,9 @@ public class ContractUpdateTransactionTest {
                 .setContractMemo("3")
                 .setStakedAccountId(AccountId.fromString("0.0.3"))
                 .setExpirationTime(Instant.ofEpochMilli(4))
-                .setProxyAccountId(new AccountId(4))
+                .setProxyAccountId(new AccountId(0, 0, 4))
                 .setMaxTransactionFee(Hbar.fromTinybars(100_000))
-                .setAutoRenewAccountId(new AccountId(30))
+                .setAutoRenewAccountId(new AccountId(0, 0, 30))
                 .freeze()
                 .sign(privateKey);
     }
@@ -75,9 +75,9 @@ public class ContractUpdateTransactionTest {
                 .setContractMemo("3")
                 .setStakedNodeId(4L)
                 .setExpirationTime(Instant.ofEpochMilli(4))
-                .setProxyAccountId(new AccountId(4))
+                .setProxyAccountId(new AccountId(0, 0, 4))
                 .setMaxTransactionFee(Hbar.fromTinybars(100_000))
-                .setAutoRenewAccountId(new AccountId(30))
+                .setAutoRenewAccountId(new AccountId(0, 0, 30))
                 .freeze()
                 .sign(privateKey);
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeLimitTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeLimitTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CustomFeeLimitTest {
-    private static final AccountId TEST_PAYER_ID = new AccountId(1234);
+    private static final AccountId TEST_PAYER_ID = new AccountId(0, 0, 1234);
 
     // Creating a sample FixedFee protobuf for testing
     private static final FixedFee TEST_FIXED_FEE_PROTO =
@@ -67,7 +67,7 @@ public class CustomFeeLimitTest {
 
     @Test
     public void testSetPayerId() {
-        AccountId newPayerId = new AccountId(5678);
+        AccountId newPayerId = new AccountId(0, 0, 5678);
 
         // Create a new instance using the builder
         CustomFeeLimit updatedFeeLimit = CustomFeeLimit.newBuilder()

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeListTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeListTest.java
@@ -24,21 +24,21 @@ public class CustomFeeListTest {
     private static List<CustomFee> spawnCustomFeeListExample() {
         var returnList = new ArrayList<CustomFee>();
         returnList.add(new CustomFixedFee()
-                .setFeeCollectorAccountId(new AccountId(4322))
-                .setDenominatingTokenId(new TokenId(483902))
+                .setFeeCollectorAccountId(new AccountId(0, 0, 4322))
+                .setDenominatingTokenId(new TokenId(0, 0, 483902))
                 .setAmount(10));
         returnList.add(new CustomFractionalFee()
-                .setFeeCollectorAccountId(new AccountId(389042))
+                .setFeeCollectorAccountId(new AccountId(0, 0, 389042))
                 .setNumerator(3)
                 .setDenominator(7)
                 .setMin(3)
                 .setMax(100));
         returnList.add(new CustomRoyaltyFee()
-                .setFeeCollectorAccountId(new AccountId(23423))
+                .setFeeCollectorAccountId(new AccountId(0, 0, 23423))
                 .setNumerator(5)
                 .setDenominator(8)
                 .setFallbackFee(new CustomFixedFee()
-                        .setDenominatingTokenId(new TokenId(483902))
+                        .setDenominatingTokenId(new TokenId(0, 0, 483902))
                         .setAmount(10)));
         return returnList;
     }
@@ -68,7 +68,7 @@ public class CustomFeeListTest {
         assertThat(originalCustomFeeListString).isEqualTo(copyCustomFeeList.toString());
 
         // modifying clone doesn't affect original
-        ((CustomFixedFee) copyCustomFeeList.get(0)).setDenominatingTokenId(new TokenId(89803));
+        ((CustomFixedFee) copyCustomFeeList.get(0)).setDenominatingTokenId(new TokenId(0, 0, 89803));
         assertThat(originalCustomFeeListString).isEqualTo(originalCustomFeeList.toString());
 
         SnapshotMatcher.expect(originalCustomFeeList.toString()).toMatchSnapshot();

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/DelegateContractIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/DelegateContractIdTest.java
@@ -41,19 +41,20 @@ class DelegateContractIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new DelegateContractId(5005).toBytes()))
+        SnapshotMatcher.expect(Hex.toHexString(new DelegateContractId(0, 0, 5005).toBytes()))
                 .toMatchSnapshot();
     }
 
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(DelegateContractId.fromBytes(new DelegateContractId(5005).toBytes())
+        SnapshotMatcher.expect(DelegateContractId.fromBytes(new DelegateContractId(0, 0, 5005).toBytes())
                         .toString())
                 .toMatchSnapshot();
     }
 
     @Test
     void toSolidityAddress() {
-        SnapshotMatcher.expect(new DelegateContractId(5005).toSolidityAddress()).toMatchSnapshot();
+        SnapshotMatcher.expect(new DelegateContractId(0, 0, 5005).toSolidityAddress())
+                .toMatchSnapshot();
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
@@ -15,8 +15,8 @@ public class ECDSAPublicKeyTest {
     @Test
     void verifyTransaction() {
         var transaction = new TransferTransaction()
-                .setNodeAccountIds(Collections.singletonList(new AccountId(3)))
-                .setTransactionId(TransactionId.generate(new AccountId(4)))
+                .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 3)))
+                .setTransactionId(TransactionId.generate(new AccountId(0, 0, 4)))
                 .freeze();
 
         var key = PrivateKey.fromStringECDSA("8776c6b831a1b61ac10dac0304a2843de4716f54b1919bb91a2685d0fe3f3048");

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
@@ -21,8 +21,8 @@ class Ed25519PublicKeyTest {
     @Test
     void verifyTransaction() {
         var transaction = new TransferTransaction()
-                .setNodeAccountIds(Collections.singletonList(new AccountId(3)))
-                .setTransactionId(TransactionId.generate(new AccountId(4)))
+                .setNodeAccountIds(Collections.singletonList(new AccountId(0, 0, 3)))
+                .setTransactionId(TransactionId.generate(new AccountId(0, 0, 4)))
                 .freeze();
 
         var key = PrivateKey.fromStringED25519("8776c6b831a1b61ac10dac0304a2843de4716f54b1919bb91a2685d0fe3f3048");

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
@@ -49,14 +49,14 @@ class ExecutableTest {
         node4 = Mockito.mock(Node.class);
         node5 = Mockito.mock(Node.class);
 
-        when(node3.getAccountId()).thenReturn(new AccountId(3));
-        when(node4.getAccountId()).thenReturn(new AccountId(4));
-        when(node5.getAccountId()).thenReturn(new AccountId(5));
-        when(network.getNodeProxies(new AccountId(3))).thenReturn(List.of(node3));
-        when(network.getNodeProxies(new AccountId(4))).thenReturn(List.of(node4));
-        when(network.getNodeProxies(new AccountId(5))).thenReturn(List.of(node5));
+        when(node3.getAccountId()).thenReturn(new AccountId(0, 0, 3));
+        when(node4.getAccountId()).thenReturn(new AccountId(0, 0, 4));
+        when(node5.getAccountId()).thenReturn(new AccountId(0, 0, 5));
+        when(network.getNodeProxies(new AccountId(0, 0, 3))).thenReturn(List.of(node3));
+        when(network.getNodeProxies(new AccountId(0, 0, 4))).thenReturn(List.of(node4));
+        when(network.getNodeProxies(new AccountId(0, 0, 5))).thenReturn(List.of(node5));
 
-        nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
     }
 
     @Test
@@ -255,8 +255,8 @@ class ExecutableTest {
                     AccountId nodeId,
                     com.hedera.hashgraph.sdk.proto.Transaction request) {
                 return new TransactionResponse(
-                                new AccountId(3),
-                                TransactionId.withValidStart(new AccountId(3), now),
+                                new AccountId(0, 0, 3),
+                                TransactionId.withValidStart(new AccountId(0, 0, 3), now),
                                 new byte[] {1, 2, 3},
                                 null,
                                 null)
@@ -264,7 +264,7 @@ class ExecutableTest {
             }
         };
 
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         var txResp = com.hedera.hashgraph.sdk.proto.TransactionResponse.newBuilder()
@@ -275,7 +275,7 @@ class ExecutableTest {
         com.hedera.hashgraph.sdk.TransactionResponse resp =
                 (com.hedera.hashgraph.sdk.TransactionResponse) tx.execute(client);
 
-        assertThat(resp.nodeId).isEqualTo(new AccountId(3));
+        assertThat(resp.nodeId).isEqualTo(new AccountId(0, 0, 3));
         assertThat(resp.getValidateStatus()).isTrue();
         assertThat(resp.toString()).isNotNull();
     }
@@ -297,15 +297,15 @@ class ExecutableTest {
                     AccountId nodeId,
                     com.hedera.hashgraph.sdk.proto.Transaction request) {
                 return new TransactionResponse(
-                        new AccountId(4),
-                        TransactionId.withValidStart(new AccountId(4), now),
+                        new AccountId(0, 0, 4),
+                        TransactionId.withValidStart(new AccountId(0, 0, 4), now),
                         new byte[] {1, 2, 3},
                         null,
                         null);
             }
         };
 
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         var txResp = com.hedera.hashgraph.sdk.proto.TransactionResponse.newBuilder()
@@ -318,7 +318,7 @@ class ExecutableTest {
 
         verify(node3).channelFailedToConnect(any(Instant.class));
         verify(node4).channelFailedToConnect(any(Instant.class));
-        assertThat(resp.nodeId).isEqualTo(new AccountId(4));
+        assertThat(resp.nodeId).isEqualTo(new AccountId(0, 0, 4));
     }
 
     @Test
@@ -351,15 +351,15 @@ class ExecutableTest {
                     AccountId nodeId,
                     com.hedera.hashgraph.sdk.proto.Transaction request) {
                 return new TransactionResponse(
-                        new AccountId(3),
-                        TransactionId.withValidStart(new AccountId(3), now),
+                        new AccountId(0, 0, 3),
+                        TransactionId.withValidStart(new AccountId(0, 0, 3), now),
                         new byte[] {1, 2, 3},
                         null,
                         null);
             }
         };
 
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         var txResp = com.hedera.hashgraph.sdk.proto.TransactionResponse.newBuilder()
@@ -373,7 +373,7 @@ class ExecutableTest {
         verify(node3, times(2)).channelFailedToConnect(any(Instant.class));
         verify(node4).channelFailedToConnect(any(Instant.class));
         verify(node5).channelFailedToConnect(any(Instant.class));
-        assertThat(resp.nodeId).isEqualTo(new AccountId(3));
+        assertThat(resp.nodeId).isEqualTo(new AccountId(0, 0, 3));
     }
 
     @Test
@@ -387,7 +387,7 @@ class ExecutableTest {
         when(node5.channelFailedToConnect(any(Instant.class))).thenReturn(true);
 
         var tx = new DummyTransaction();
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
         assertThatExceptionOfType(MaxAttemptsExceededException.class).isThrownBy(() -> tx.execute(client));
     }
@@ -403,7 +403,7 @@ class ExecutableTest {
         when(node4.channelFailedToConnect(any(Instant.class))).thenReturn(false);
 
         var tx = new DummyTransaction();
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         tx.blockingUnaryCall = (grpcRequest) -> {
@@ -423,8 +423,8 @@ class ExecutableTest {
     @Test
     void testChannelFailedToConnectTimeout() {
         TransactionResponse transactionResponse = new TransactionResponse(
-                new AccountId(3),
-                TransactionId.withValidStart(new AccountId(3), java.time.Instant.now()),
+                new AccountId(0, 0, 3),
+                TransactionId.withValidStart(new AccountId(0, 0, 3), java.time.Instant.now()),
                 new byte[] {1, 2, 3},
                 null,
                 null);
@@ -461,7 +461,7 @@ class ExecutableTest {
                 return i.getAndIncrement() == 0 ? ExecutionState.RETRY : ExecutionState.SUCCESS;
             }
         };
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         var receipt = com.hedera.hashgraph.sdk.proto.TransactionReceipt.newBuilder()
@@ -490,7 +490,7 @@ class ExecutableTest {
                 return Status.ACCOUNT_DELETED;
             }
         };
-        var nodeAccountIds = Arrays.asList(new AccountId(3), new AccountId(4), new AccountId(5));
+        var nodeAccountIds = Arrays.asList(new AccountId(0, 0, 3), new AccountId(0, 0, 4), new AccountId(0, 0, 5));
         tx.setNodeAccountIds(nodeAccountIds);
 
         var txResp = com.hedera.hashgraph.sdk.proto.TransactionResponse.newBuilder()

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
@@ -26,12 +26,14 @@ class FileIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new FileId(5005).toBytes())).toMatchSnapshot();
+        SnapshotMatcher.expect(Hex.toHexString(new FileId(0, 0, 5005).toBytes()))
+                .toMatchSnapshot();
     }
 
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(FileId.fromBytes(new FileId(5005).toBytes()).toString())
+        SnapshotMatcher.expect(
+                        FileId.fromBytes(new FileId(0, 0, 5005).toBytes()).toString())
                 .toMatchSnapshot();
     }
 
@@ -44,6 +46,6 @@ class FileIdTest {
 
     @Test
     void toSolidityAddress() {
-        SnapshotMatcher.expect(new FileId(5005).toSolidityAddress()).toMatchSnapshot();
+        SnapshotMatcher.expect(new FileId(0, 0, 5005).toSolidityAddress()).toMatchSnapshot();
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoTest.java
@@ -16,7 +16,7 @@ public class FileInfoTest {
             "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
 
     private static final FileGetInfoResponse.FileInfo info = FileGetInfoResponse.FileInfo.newBuilder()
-            .setFileID(new FileId(1).toProtobuf())
+            .setFileID(new FileId(0, 0, 1).toProtobuf())
             .setSize(2)
             .setExpirationTime(InstantConverter.toProtobuf(Instant.ofEpochMilli(3)))
             .setDeleted(true)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HederaTrustManagerTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HederaTrustManagerTest.java
@@ -75,26 +75,26 @@ public class HederaTrustManagerTest {
 
     @Test
     void properlyChecksCertificateAgainstCurrentNetworkAddressBook() throws InterruptedException, CertificateException {
-        var client = Client.forNetwork(Map.of("0.previewnet.hedera.com:50211", new AccountId(3)))
+        var client = Client.forNetwork(Map.of("0.previewnet.hedera.com:50211", new AccountId(0, 0, 3)))
                 .setTransportSecurity(true)
                 .setVerifyCertificates(true)
                 .setLedgerId(LedgerId.PREVIEWNET);
 
         var nodeAddress = Objects.requireNonNull(
-                Objects.requireNonNull(client.network.addressBook).get(new AccountId(3)));
+                Objects.requireNonNull(client.network.addressBook).get(new AccountId(0, 0, 3)));
         new HederaTrustManager(nodeAddress.getCertHash(), client.isVerifyCertificates())
                 .checkServerTrusted(CERTIFICATE_CHAIN, "");
     }
 
     @Test
     void certificateCheckFailWhenHashMismatches() throws InterruptedException, CertificateException {
-        var client = Client.forNetwork(Map.of("0.previewnet.hedera.com:50211", new AccountId(3)))
+        var client = Client.forNetwork(Map.of("0.previewnet.hedera.com:50211", new AccountId(0, 0, 3)))
                 .setTransportSecurity(true)
                 .setVerifyCertificates(true)
                 .setLedgerId(LedgerId.PREVIEWNET);
 
         var nodeAddress = Objects.requireNonNull(
-                Objects.requireNonNull(client.network.addressBook).get(new AccountId(4)));
+                Objects.requireNonNull(client.network.addressBook).get(new AccountId(0, 0, 4)));
         assertThatExceptionOfType(CertificateException.class)
                 .isThrownBy(() -> new HederaTrustManager(nodeAddress.getCertHash(), client.isVerifyCertificates())
                         .checkServerTrusted(CERTIFICATE_CHAIN, ""));

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Mocker.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Mocker.java
@@ -46,7 +46,7 @@ public class Mocker implements AutoCloseable {
             var index = new AtomicInteger();
             var response = responses.get(i);
             var name = InProcessServerBuilder.generateName();
-            var nodeAccountId = new AccountId(3 + i);
+            var nodeAccountId = new AccountId(0, 0, 3 + i);
             var builder = InProcessServerBuilder.forName(name);
 
             network.put("in-process:" + name, nodeAccountId);
@@ -99,7 +99,7 @@ public class Mocker implements AutoCloseable {
         }
 
         this.client = Client.forNetwork(network)
-                .setOperator(new AccountId(1800), PRIVATE_KEY)
+                .setOperator(new AccountId(0, 0, 1800), PRIVATE_KEY)
                 .setMinBackoff(Duration.ofMillis(0))
                 .setMaxBackoff(Duration.ofMillis(0))
                 .setNodeMinBackoff(Duration.ofMillis(0))

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/MockingTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/MockingTest.java
@@ -60,8 +60,9 @@ public class MockingTest {
         var responses = List.of(responses1);
 
         try (var mocker = Mocker.withResponses(responses)) {
-            var balance =
-                    new AccountBalanceQuery().setAccountId(new AccountId(10)).execute(mocker.client);
+            var balance = new AccountBalanceQuery()
+                    .setAccountId(new AccountId(0, 0, 10))
+                    .execute(mocker.client);
 
             Assertions.assertEquals(balance.hbars, Hbar.fromTinybars(100));
         }
@@ -372,7 +373,7 @@ public class MockingTest {
 
         try (var mocker = Mocker.withResponses(responses)) {
             Assertions.assertThrows(RuntimeException.class, () -> new AccountBalanceQuery()
-                    .setAccountId(new AccountId(10))
+                    .setAccountId(new AccountId(0, 0, 10))
                     .execute(mocker.client));
         }
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
@@ -70,14 +70,15 @@ class NftIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new TokenId(5005).nft(4920).toBytes()))
+        SnapshotMatcher.expect(Hex.toHexString(new TokenId(0, 0, 5005).nft(4920).toBytes()))
                 .toMatchSnapshot();
     }
 
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
         SnapshotMatcher.expect(
-                        NftId.fromBytes(new TokenId(5005).nft(574489).toBytes()).toString())
+                        NftId.fromBytes(new TokenId(0, 0, 5005).nft(574489).toBytes())
+                                .toString())
                 .toMatchSnapshot();
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/PendingAirdropIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/PendingAirdropIdTest.java
@@ -17,10 +17,10 @@ class PendingAirdropIdTest {
 
     @BeforeEach
     void setUp() {
-        sender = new AccountId(1001);
-        receiver = new AccountId(1002);
-        tokenId = new TokenId(1003);
-        nftId = new NftId(new TokenId(1004), 1);
+        sender = new AccountId(0, 0, 1001);
+        receiver = new AccountId(0, 0, 1002);
+        tokenId = new TokenId(0, 0, 1003);
+        nftId = new NftId(new TokenId(0, 0, 1004), 1);
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ProxyStakerTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ProxyStakerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 public class ProxyStakerTest {
     private static final ProxyStaker proxyStaker = ProxyStaker.newBuilder()
-            .setAccountID(new AccountId(100).toProtobuf())
+            .setAccountID(new AccountId(0, 0, 100).toProtobuf())
             .setAmount(10)
             .build();
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFeeScheduleUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFeeScheduleUpdateTransactionTest.java
@@ -30,11 +30,11 @@ public class TokenFeeScheduleUpdateTransactionTest {
     private TokenFeeScheduleUpdateTransaction spawnTestTransaction() {
         var customFees = new ArrayList<CustomFee>();
         customFees.add(new CustomFixedFee()
-                .setFeeCollectorAccountId(new AccountId(4322))
-                .setDenominatingTokenId(new TokenId(483902))
+                .setFeeCollectorAccountId(new AccountId(0, 0, 4322))
+                .setDenominatingTokenId(new TokenId(0, 0, 483902))
                 .setAmount(10));
         customFees.add(new CustomFractionalFee()
-                .setFeeCollectorAccountId(new AccountId(389042))
+                .setFeeCollectorAccountId(new AccountId(0, 0, 389042))
                 .setNumerator(3)
                 .setDenominator(7)
                 .setMin(3)
@@ -42,7 +42,7 @@ public class TokenFeeScheduleUpdateTransactionTest {
                 .setAssessmentMethod(FeeAssessmentMethod.EXCLUSIVE));
 
         return new TokenFeeScheduleUpdateTransaction()
-                .setTokenId(new TokenId(8798))
+                .setTokenId(new TokenId(0, 0, 8798))
                 .setCustomFees(customFees)
                 .setNodeAccountIds(Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
                 .setTransactionId(TransactionId.withValidStart(AccountId.fromString("0.0.5006"), validStart))

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoTest.java
@@ -60,11 +60,11 @@ public class TokenInfoTest {
     private static final boolean testTokenIsDeleted = false;
     private static final List<CustomFee> testTokenCustomFees = Arrays.asList(
             new CustomFixedFee()
-                    .setFeeCollectorAccountId(new AccountId(4322))
-                    .setDenominatingTokenId(new TokenId(483902))
+                    .setFeeCollectorAccountId(new AccountId(0, 0, 4322))
+                    .setDenominatingTokenId(new TokenId(0, 0, 483902))
                     .setAmount(10),
             new CustomFractionalFee()
-                    .setFeeCollectorAccountId(new AccountId(389042))
+                    .setFeeCollectorAccountId(new AccountId(0, 0, 389042))
                     .setNumerator(3)
                     .setDenominator(7)
                     .setMin(3)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicCreateTransactionTest.java
@@ -129,9 +129,9 @@ public class TopicCreateTransactionTest {
     @Test
     void shouldSetTopicCustomFees() {
         List<CustomFixedFee> customFixedFees = new ArrayList<>(List.of(
-                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0)),
-                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(1)),
-                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(2))));
+                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 0)),
+                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(0, 0, 1)),
+                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 2))));
 
         TopicCreateTransaction topicCreateTransaction = new TopicCreateTransaction();
         topicCreateTransaction.setCustomFees(customFixedFees);
@@ -144,12 +144,12 @@ public class TopicCreateTransactionTest {
     @Test
     void shouldAddTopicCustomFeeToList() {
         List<CustomFixedFee> customFixedFees = new ArrayList<>(List.of(
-                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0)),
-                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(1)),
-                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(2))));
+                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 0)),
+                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(0, 0, 1)),
+                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 2))));
 
         CustomFixedFee customFixedFeeToBeAdded =
-                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(3));
+                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(0, 0, 3));
 
         List<CustomFixedFee> expectedCustomFees = new ArrayList<>(customFixedFees);
         expectedCustomFees.add(customFixedFeeToBeAdded);
@@ -166,7 +166,7 @@ public class TopicCreateTransactionTest {
     @Test
     void shouldAddTopicCustomFeeToEmptyList() {
         CustomFixedFee customFixedFeeToBeAdded =
-                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(3));
+                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(0, 0, 3));
 
         TopicCreateTransaction topicCreateTransaction = new TopicCreateTransaction();
         topicCreateTransaction.addCustomFee(customFixedFeeToBeAdded);

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicIdTest.java
@@ -26,12 +26,14 @@ class TopicIdTest {
 
     @Test
     void toBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(Hex.toHexString(new TopicId(5005).toBytes())).toMatchSnapshot();
+        SnapshotMatcher.expect(Hex.toHexString(new TopicId(0, 0, 5005).toBytes()))
+                .toMatchSnapshot();
     }
 
     @Test
     void fromBytes() throws InvalidProtocolBufferException {
-        SnapshotMatcher.expect(TopicId.fromBytes(new TopicId(5005).toBytes()).toString())
+        SnapshotMatcher.expect(
+                        TopicId.fromBytes(new TopicId(0, 0, 5005).toBytes()).toString())
                 .toMatchSnapshot();
     }
 
@@ -44,6 +46,6 @@ class TopicIdTest {
 
     @Test
     void toSolidityAddress() {
-        SnapshotMatcher.expect(new TokenId(5005).toSolidityAddress()).toMatchSnapshot();
+        SnapshotMatcher.expect(new TokenId(0, 0, 5005).toSolidityAddress()).toMatchSnapshot();
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoTest.java
@@ -30,7 +30,7 @@ public class TopicInfoTest {
     private static final byte[] hash = {2};
 
     private static final List<CustomFixedFee> customFees =
-            List.of(new CustomFixedFee().setAmount(100).setDenominatingTokenId(new TokenId(0)));
+            List.of(new CustomFixedFee().setAmount(100).setDenominatingTokenId(new TokenId(0, 0, 0)));
 
     private static final ConsensusGetTopicInfoResponse info = ConsensusGetTopicInfoResponse.newBuilder()
             .setTopicInfo(ConsensusTopicInfo.newBuilder()
@@ -48,7 +48,7 @@ public class TopicInfoTest {
                     .addAllCustomFees(customFees.stream()
                             .map(CustomFixedFee::toTopicFeeProtobuf)
                             .toList())
-                    .setAutoRenewAccount(new AccountId(4).toProtobuf())
+                    .setAutoRenewAccount(new AccountId(0, 0, 4).toProtobuf())
                     .setLedgerId(LedgerId.TESTNET.toByteString()))
             .build();
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageChunkTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageChunkTest.java
@@ -16,7 +16,7 @@ public class TopicMessageChunkTest {
     private static final byte[] testContents = new byte[] {0x01, 0x02, 0x03};
     private static final byte[] testRunningHash = new byte[] {0x04, 0x05, 0x06};
     private static final long testSequenceNumber = 7L;
-    private static final TransactionId testTransactionId = new TransactionId(new AccountId(1), testTimestamp);
+    private static final TransactionId testTransactionId = new TransactionId(new AccountId(0, 0, 1), testTimestamp);
 
     @Test
     void constructWithArgs() {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageSubmitTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageSubmitTransactionTest.java
@@ -125,13 +125,13 @@ public class TopicMessageSubmitTransactionTest {
     void shouldSetCustomFeeLimits() {
         var customFeeLimits = Arrays.asList(
                 new CustomFeeLimit()
-                        .setPayerId(new AccountId(1))
-                        .setCustomFees(
-                                List.of(new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(1)))),
+                        .setPayerId(new AccountId(0, 0, 1))
+                        .setCustomFees(List.of(
+                                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 1)))),
                 new CustomFeeLimit()
-                        .setPayerId(new AccountId(2))
-                        .setCustomFees(
-                                List.of(new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(2)))));
+                        .setPayerId(new AccountId(0, 0, 2))
+                        .setCustomFees(List.of(
+                                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 2)))));
 
         var topicMessageSubmitTransaction = new TopicMessageSubmitTransaction().setCustomFeeLimits(customFeeLimits);
 
@@ -142,18 +142,18 @@ public class TopicMessageSubmitTransactionTest {
     void shouldAddCustomFeeLimitToList() {
         var customFeeLimits = new ArrayList<>(List.of(
                 new CustomFeeLimit()
-                        .setPayerId(new AccountId(1))
-                        .setCustomFees(
-                                List.of(new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(1)))),
+                        .setPayerId(new AccountId(0, 0, 1))
+                        .setCustomFees(List.of(
+                                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 1)))),
                 new CustomFeeLimit()
-                        .setPayerId(new AccountId(2))
-                        .setCustomFees(
-                                List.of(new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(2))))));
+                        .setPayerId(new AccountId(0, 0, 2))
+                        .setCustomFees(List.of(
+                                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 2))))));
 
         var customFeeLimitToBeAdded = new CustomFeeLimit()
-                .setPayerId(new AccountId(3))
+                .setPayerId(new AccountId(0, 0, 3))
                 .setCustomFees(new ArrayList<>(
-                        List.of(new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(3)))));
+                        List.of(new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 3)))));
 
         var expectedCustomFeeLimits = new ArrayList<>(customFeeLimits);
         expectedCustomFeeLimits.add(customFeeLimitToBeAdded);
@@ -168,9 +168,9 @@ public class TopicMessageSubmitTransactionTest {
     @Test
     void shouldAddCustomFeeLimitToEmptyList() {
         var customFeeLimitToBeAdded = new CustomFeeLimit()
-                .setPayerId(new AccountId(3))
+                .setPayerId(new AccountId(0, 0, 3))
                 .setCustomFees(new ArrayList<>(
-                        List.of(new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(3)))));
+                        List.of(new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 3)))));
 
         var topicMessageSubmitTransaction =
                 new TopicMessageSubmitTransaction().addCustomFeeLimit(customFeeLimitToBeAdded);

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageTest.java
@@ -17,7 +17,7 @@ public class TopicMessageTest {
     private static final byte[] testContents = new byte[] {0x01, 0x02, 0x03};
     private static final byte[] testRunningHash = new byte[] {0x04, 0x05, 0x06};
     private static final long testSequenceNumber = 7L;
-    private static final TransactionId testTransactionId = new TransactionId(new AccountId(1), testTimestamp);
+    private static final TransactionId testTransactionId = new TransactionId(new AccountId(0, 0, 1), testTimestamp);
 
     @Test
     void constructWithArgs() {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicUpdateTransactionTest.java
@@ -276,7 +276,7 @@ public class TopicUpdateTransactionTest {
     void clearAutoRenewAccountId() {
         var topicUpdateTransaction = new TopicUpdateTransaction().setAutoRenewAccountId(testAutoRenewAccountId);
         topicUpdateTransaction.clearAutoRenewAccountId();
-        assertThat(topicUpdateTransaction.getAutoRenewAccountId()).isEqualTo(new AccountId(0));
+        assertThat(topicUpdateTransaction.getAutoRenewAccountId()).isEqualTo(new AccountId(0, 0, 0));
     }
 
     @Test
@@ -344,9 +344,9 @@ public class TopicUpdateTransactionTest {
     @Test
     void shouldSetCustomFees() {
         List<CustomFixedFee> customFixedFees = List.of(
-                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0)),
-                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(1)),
-                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(2)));
+                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 0)),
+                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(0, 0, 1)),
+                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 2)));
 
         TopicUpdateTransaction topicUpdateTransaction = new TopicUpdateTransaction();
         topicUpdateTransaction.setCustomFees(new ArrayList<>(customFixedFees));
@@ -357,12 +357,12 @@ public class TopicUpdateTransactionTest {
     @Test
     void shouldAddCustomFeeToList() {
         List<CustomFixedFee> customFixedFees = List.of(
-                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0)),
-                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(1)),
-                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(2)));
+                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 0)),
+                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(0, 0, 1)),
+                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 2)));
 
         CustomFixedFee customFixedFeeToBeAdded =
-                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(3));
+                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(0, 0, 3));
 
         List<CustomFixedFee> expectedCustomFees = new ArrayList<>(customFixedFees);
         expectedCustomFees.add(customFixedFeeToBeAdded);
@@ -377,7 +377,7 @@ public class TopicUpdateTransactionTest {
     @Test
     void shouldAddCustomFeeToEmptyList() {
         CustomFixedFee customFixedFeeToBeAdded =
-                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(3));
+                new CustomFixedFee().setAmount(4).setDenominatingTokenId(new TokenId(0, 0, 3));
 
         TopicUpdateTransaction topicUpdateTransaction = new TopicUpdateTransaction();
         topicUpdateTransaction.addCustomFee(customFixedFeeToBeAdded);
@@ -388,9 +388,9 @@ public class TopicUpdateTransactionTest {
     @Test
     void shouldClearCustomFees() {
         List<CustomFixedFee> customFixedFees = List.of(
-                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0)),
-                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(1)),
-                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(2)));
+                new CustomFixedFee().setAmount(1).setDenominatingTokenId(new TokenId(0, 0, 0)),
+                new CustomFixedFee().setAmount(2).setDenominatingTokenId(new TokenId(0, 0, 1)),
+                new CustomFixedFee().setAmount(3).setDenominatingTokenId(new TokenId(0, 0, 2)));
 
         TopicUpdateTransaction topicUpdateTransaction = new TopicUpdateTransaction();
         topicUpdateTransaction.setCustomFees(new ArrayList<>(customFixedFees));

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
@@ -29,8 +29,8 @@ public class TransactionTest {
 
         var transaction = (TransferTransaction) fromBytes(bytes);
 
-        assertThat(transaction.getHbarTransfers()).containsEntry(new AccountId(476260), new Hbar(1).negated());
-        assertThat(transaction.getHbarTransfers()).containsEntry(new AccountId(476267), new Hbar(1));
+        assertThat(transaction.getHbarTransfers()).containsEntry(new AccountId(0, 0, 476260), new Hbar(1).negated());
+        assertThat(transaction.getHbarTransfers()).containsEntry(new AccountId(0, 0, 476267), new Hbar(1));
     }
 
     @Test

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -21,12 +21,12 @@ public class ClientIntegrationTest {
         var client = Client.forTestnet().setTransportSecurity(true);
 
         var nodes = new ArrayList<AccountId>();
-        nodes.add(new AccountId(1000));
-        nodes.add(new AccountId(1001));
+        nodes.add(new AccountId(0, 0, 1000));
+        nodes.add(new AccountId(0, 0, 1001));
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> new AccountBalanceQuery()
                         .setNodeAccountIds(nodes)
-                        .setAccountId(new AccountId(7))
+                        .setAccountId(new AccountId(0, 0, 7))
                         .execute(client))
                 .withMessageContaining("All node account IDs did not map to valid nodes in the client's network");
         client.close();
@@ -38,10 +38,10 @@ public class ClientIntegrationTest {
         var client = Client.forTestnet().setTransportSecurity(true);
 
         var nodes = new ArrayList<>(client.getNetwork().values().stream().toList());
-        nodes.add(new AccountId(1000));
+        nodes.add(new AccountId(0, 0, 1000));
         new AccountBalanceQuery()
                 .setNodeAccountIds(nodes)
-                .setAccountId(new AccountId(7))
+                .setAccountId(new AccountId(0, 0, 7))
                 .execute(client);
 
         client.close();
@@ -51,8 +51,8 @@ public class ClientIntegrationTest {
     @DisplayName("setNetwork() functions correctly")
     void testReplaceNodes() throws Exception {
         Map<String, AccountId> network = new HashMap<>();
-        network.put("0.testnet.hedera.com:50211", new AccountId(3));
-        network.put("1.testnet.hedera.com:50211", new AccountId(4));
+        network.put("0.testnet.hedera.com:50211", new AccountId(0, 0, 3));
+        network.put("1.testnet.hedera.com:50211", new AccountId(0, 0, 4));
 
         try (var testEnv = new IntegrationTestEnv(1)) {
 
@@ -64,19 +64,19 @@ public class ClientIntegrationTest {
             assertThat(testEnv.operatorId).isNotNull();
 
             // Execute two simple queries so we create a channel for each network node.
-            new AccountBalanceQuery().setAccountId(new AccountId(3)).execute(testEnv.client);
+            new AccountBalanceQuery().setAccountId(new AccountId(0, 0, 3)).execute(testEnv.client);
 
-            new AccountBalanceQuery().setAccountId(new AccountId(3)).execute(testEnv.client);
+            new AccountBalanceQuery().setAccountId(new AccountId(0, 0, 3)).execute(testEnv.client);
 
             network = new HashMap<>();
-            network.put("1.testnet.hedera.com:50211", new AccountId(4));
-            network.put("2.testnet.hedera.com:50211", new AccountId(5));
+            network.put("1.testnet.hedera.com:50211", new AccountId(0, 0, 4));
+            network.put("2.testnet.hedera.com:50211", new AccountId(0, 0, 5));
 
             testEnv.client.setNetwork(network);
 
             network = new HashMap<>();
-            network.put("35.186.191.247:50211", new AccountId(4));
-            network.put("35.192.2.25:50211", new AccountId(5));
+            network.put("35.186.191.247:50211", new AccountId(0, 0, 4));
+            network.put("35.192.2.25:50211", new AccountId(0, 0, 5));
 
             testEnv.client.setNetwork(network);
         }

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/IntegrationTestEnv.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/IntegrationTestEnv.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assumptions;
 public class IntegrationTestEnv implements AutoCloseable {
     static final String LOCAL_CONSENSUS_NODE_ENDPOINT = "127.0.0.1:50211";
     static final String LOCAL_MIRROR_NODE_GRPC_ENDPOINT = "127.0.0.1:5600";
-    static final AccountId LOCAL_CONSENSUS_NODE_ACCOUNT_ID = new AccountId(3);
+    static final AccountId LOCAL_CONSENSUS_NODE_ACCOUNT_ID = new AccountId(0, 0, 3);
     private final Client originalClient;
     public Client client;
     public PublicKey operatorKey;

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/MirrorNodeContractQueryIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/MirrorNodeContractQueryIntegrationTest.java
@@ -103,7 +103,7 @@ class MirrorNodeContractQueryIntegrationTest {
     void returnsDefaultValuesWhenContractIsNotDeployed() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
             var defaultGas = 22892;
-            var contractId = new ContractId(1231456);
+            var contractId = new ContractId(0, 0, 1231456);
 
             var gas = new MirrorNodeContractEstimateGasQuery()
                     .setContractId(contractId)

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/NodeCreateTransactionIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/NodeCreateTransactionIntegrationTest.java
@@ -33,7 +33,7 @@ class NodeCreateTransactionIntegrationTest {
             // Set the operator to be account 0.0.2
             var originalOperatorKey = PrivateKey.fromString(
                     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
-            client.setOperator(new AccountId(2), originalOperatorKey);
+            client.setOperator(new AccountId(0, 0, 2), originalOperatorKey);
 
             // The account of the new node
             var accountID = AccountId.fromString("0.0.4");

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenManualAssociationIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenManualAssociationIntegrationTest.java
@@ -103,7 +103,7 @@ class TokenManualAssociationIntegrationTest {
             var contractId = EntityHelper.createContract(testEnv, testEnv.operatorKey);
 
             new TokenAssociateTransaction()
-                    .setAccountId(new AccountId(contractId.num))
+                    .setAccountId(new AccountId(0, 0, contractId.num))
                     .setTokenIds(Collections.singletonList(tokenId))
                     .freezeWith(testEnv.client)
                     .execute(testEnv.client)
@@ -138,7 +138,7 @@ class TokenManualAssociationIntegrationTest {
             var contractId = EntityHelper.createContract(testEnv, testEnv.operatorKey);
 
             new TokenAssociateTransaction()
-                    .setAccountId(new AccountId(contractId.num))
+                    .setAccountId(new AccountId(0, 0, contractId.num))
                     .setTokenIds(Collections.singletonList(tokenId))
                     .freezeWith(testEnv.client)
                     .execute(testEnv.client)

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TransactionIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TransactionIntegrationTest.java
@@ -716,7 +716,7 @@ public class TransactionIntegrationTest {
     @DisplayName("transaction can be serialized into bytes, deserialized, signature added and executed")
     void transactionFromToBytes2() {
         assertThatNoException().isThrownBy(() -> {
-            var id = TransactionId.generate(new AccountId(542348));
+            var id = TransactionId.generate(new AccountId(0, 0, 542348));
 
             var transactionBodyBuilder = TransactionBody.newBuilder();
             transactionBodyBuilder
@@ -823,25 +823,32 @@ public class TransactionIntegrationTest {
 
             try (var testEnv = new IntegrationTestEnv(1)) {
 
-                assertThat(tx.getHbarTransfers().get(new AccountId(542348)).toTinybars())
+                assertThat(tx.getHbarTransfers()
+                                .get(new AccountId(0, 0, 542348))
+                                .toTinybars())
                         .isEqualTo(-10);
-                assertThat(tx.getHbarTransfers().get(new AccountId(47439)).toTinybars())
+                assertThat(tx.getHbarTransfers().get(new AccountId(0, 0, 47439)).toTinybars())
                         .isEqualTo(10);
 
                 assertThat(tx.getNodeAccountIds()).isNotNull();
                 assertThat(tx.getNodeAccountIds().size()).isEqualTo(1);
-                assertThat(tx.getNodeAccountIds().get(0)).isEqualTo(new AccountId(3));
+                assertThat(tx.getNodeAccountIds().get(0)).isEqualTo(new AccountId(0, 0, 3));
 
                 var signatures = tx.getSignatures();
-                assertThat(Arrays.toString(signatures.get(new AccountId(3)).get(publicKey1)))
+                assertThat(Arrays.toString(
+                                signatures.get(new AccountId(0, 0, 3)).get(publicKey1)))
                         .isEqualTo(Arrays.toString(signature1));
-                assertThat(Arrays.toString(signatures.get(new AccountId(3)).get(publicKey2)))
+                assertThat(Arrays.toString(
+                                signatures.get(new AccountId(0, 0, 3)).get(publicKey2)))
                         .isEqualTo(Arrays.toString(signature2));
-                assertThat(Arrays.toString(signatures.get(new AccountId(3)).get(publicKey3)))
+                assertThat(Arrays.toString(
+                                signatures.get(new AccountId(0, 0, 3)).get(publicKey3)))
                         .isEqualTo(Arrays.toString(signature3));
-                assertThat(Arrays.toString(signatures.get(new AccountId(3)).get(publicKey4)))
+                assertThat(Arrays.toString(
+                                signatures.get(new AccountId(0, 0, 3)).get(publicKey4)))
                         .isEqualTo(Arrays.toString(signature4));
-                assertThat(Arrays.toString(signatures.get(new AccountId(3)).get(publicKey5)))
+                assertThat(Arrays.toString(
+                                signatures.get(new AccountId(0, 0, 3)).get(publicKey5)))
                         .isEqualTo(Arrays.toString(signature5));
 
                 var resp = tx.execute(testEnv.client);


### PR DESCRIPTION
**Description**:
deprecate methods that explicitly set shard and realm to 0
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #
https://github.com/hiero-ledger/hiero-sdk-java/issues/2231
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
