### PR TITLE
chore: introduce new FileId methods for non zero shard and realm hand…

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
@@ -44,7 +44,7 @@ public class InitializeClientWithMirrorNetworkExample {
          * Step 0:
          * Create and configure the SDK Client.
          */
-        Client client = Client.forMirrorNetwork(List.of("testnet.mirrornode.hedera.com:443"));
+        Client client = Client.forMirrorNetwork(List.of("testnet.mirrornode.hedera.com:443"), 0 , 0);
         // All generated transactions will be paid by this account and signed by this key.
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
         // Attach logger to the SDK Client.

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
@@ -44,7 +44,7 @@ public class InitializeClientWithMirrorNetworkExample {
          * Step 0:
          * Create and configure the SDK Client.
          */
-        Client client = Client.forMirrorNetwork(List.of("testnet.mirrornode.hedera.com:443"), 0 , 0);
+        Client client = Client.forMirrorNetwork(List.of("testnet.mirrornode.hedera.com:443"), 0, 0);
         // All generated transactions will be paid by this account and signed by this key.
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
         // Attach logger to the SDK Client.

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -185,15 +185,7 @@ public final class Client implements AutoCloseable {
      */
     public static Client forMirrorNetwork(List<String> mirrorNetworkList)
             throws InterruptedException, TimeoutException {
-        var executor = createExecutor();
-        var network = Network.forNetwork(executor, new HashMap<>());
-        var mirrorNetwork = MirrorNetwork.forNetwork(executor, mirrorNetworkList);
-        var client = new Client(executor, network, mirrorNetwork, null, true, null);
-        var addressBook = new AddressBookQuery()
-                .setFileId(FileId.getAddressBookFileIdFor(0, 0))
-                .execute(client);
-        client.setNetworkFromAddressBook(addressBook);
-        return client;
+        return forMirrorNetwork(mirrorNetworkList, 0, 0);
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -178,6 +178,7 @@ public final class Client implements AutoCloseable {
 
     /**
      * Set up the client from selected mirror network.
+     * Using default `0` values for realm and shard for retrieving addressBookFileId
      *
      * @param mirrorNetworkList
      * @return
@@ -188,7 +189,30 @@ public final class Client implements AutoCloseable {
         var network = Network.forNetwork(executor, new HashMap<>());
         var mirrorNetwork = MirrorNetwork.forNetwork(executor, mirrorNetworkList);
         var client = new Client(executor, network, mirrorNetwork, null, true, null);
-        var addressBook = new AddressBookQuery().setFileId(FileId.ADDRESS_BOOK).execute(client);
+        var addressBook = new AddressBookQuery()
+                .setFileId(FileId.getAddressBookFileIdFor(0, 0))
+                .execute(client);
+        client.setNetworkFromAddressBook(addressBook);
+        return client;
+    }
+
+    /**
+     * Set up the client from selected mirror network and given realm and shard
+     *
+     * @param mirrorNetworkList
+     * @param realm
+     * @param shard
+     * @return
+     */
+    public static Client forMirrorNetwork(List<String> mirrorNetworkList, int realm, int shard)
+            throws InterruptedException, TimeoutException {
+        var executor = createExecutor();
+        var network = Network.forNetwork(executor, new HashMap<>());
+        var mirrorNetwork = MirrorNetwork.forNetwork(executor, mirrorNetworkList);
+        var client = new Client(executor, network, mirrorNetwork, null, true, null);
+        var addressBook = new AddressBookQuery()
+                .setFileId(FileId.getAddressBookFileIdFor(realm, shard))
+                .execute(client);
         client.setNetworkFromAddressBook(addressBook);
         return client;
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
@@ -89,7 +89,7 @@ public final class FileId implements Comparable<FileId> {
      * @param shard
      * @return FileId
      */
-    public static FileId getAddressBookFileIdFor(int shard, int realm) {
+    public static FileId getAddressBookFileIdFor(long shard, long realm) {
         return new FileId(shard, realm, 102);
     }
 
@@ -99,7 +99,7 @@ public final class FileId implements Comparable<FileId> {
      * @param shard
      * @return FileId
      */
-    public static FileId getFeeScheduleFileIdFor(int shard, int realm) {
+    public static FileId getFeeScheduleFileIdFor(long shard, long realm) {
         return new FileId(shard, realm, 111);
     }
 
@@ -109,7 +109,7 @@ public final class FileId implements Comparable<FileId> {
      * @param shard
      * @return FileId
      */
-    public static FileId getExchangeRatesFileIdFor(int shard, int realm) {
+    public static FileId getExchangeRatesFileIdFor(long shard, long realm) {
         return new FileId(shard, realm, 112);
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileId.java
@@ -84,6 +84,36 @@ public final class FileId implements Comparable<FileId> {
     }
 
     /**
+     * Get the `FileId` of the Hedera address book for the given realm and shard.
+     * @param realm
+     * @param shard
+     * @return FileId
+     */
+    public static FileId getAddressBookFileIdFor(int shard, int realm) {
+        return new FileId(shard, realm, 102);
+    }
+
+    /**
+     * Get the `FileId` of the Hedera fee schedule for the given realm and shard.
+     * @param realm
+     * @param shard
+     * @return FileId
+     */
+    public static FileId getFeeScheduleFileIdFor(int shard, int realm) {
+        return new FileId(shard, realm, 111);
+    }
+
+    /**
+     * Get the `FileId` of the Hedera exchange rates for the given realm and shard.
+     * @param realm
+     * @param shard
+     * @return FileId
+     */
+    public static FileId getExchangeRatesFileIdFor(int shard, int realm) {
+        return new FileId(shard, realm, 112);
+    }
+
+    /**
      * Assign the file id from a string.
      *
      * @param id                        the string representation of a file id

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.github.jsonSnapshot.SnapshotMatcher;
 import org.bouncycastle.util.encoders.Hex;
@@ -47,5 +50,68 @@ class FileIdTest {
     @Test
     void toSolidityAddress() {
         SnapshotMatcher.expect(new FileId(0, 0, 5005).toSolidityAddress()).toMatchSnapshot();
+    }
+
+    @Test
+    void getAddressBookFileIdForReturnsCorrectFileId() {
+        FileId defaultAddressBook = FileId.getAddressBookFileIdFor(0, 0);
+        assertNotNull(defaultAddressBook);
+        assertEquals(0, defaultAddressBook.shard);
+        assertEquals(0, defaultAddressBook.realm);
+        assertEquals(102, defaultAddressBook.num);
+
+        int testShard = 5;
+        int testRealm = 10;
+        FileId customAddressBook = FileId.getAddressBookFileIdFor(testShard, testRealm);
+        assertNotNull(customAddressBook);
+        assertEquals(testShard, customAddressBook.shard);
+        assertEquals(testRealm, customAddressBook.realm);
+        assertEquals(102, customAddressBook.num);
+
+        assertEquals("5.10.102", customAddressBook.toString());
+
+        SnapshotMatcher.expect(customAddressBook.toString()).toMatchSnapshot();
+    }
+
+    @Test
+    void getFeeScheduleFileIdForReturnsCorrectFileId() {
+        FileId defaultFeeSchedule = FileId.getFeeScheduleFileIdFor(0, 0);
+        assertNotNull(defaultFeeSchedule);
+        assertEquals(0, defaultFeeSchedule.shard);
+        assertEquals(0, defaultFeeSchedule.realm);
+        assertEquals(111, defaultFeeSchedule.num);
+
+        int testShard = 7;
+        int testRealm = 12;
+        FileId customFeeSchedule = FileId.getFeeScheduleFileIdFor(testShard, testRealm);
+        assertNotNull(customFeeSchedule);
+        assertEquals(testShard, customFeeSchedule.shard);
+        assertEquals(testRealm, customFeeSchedule.realm);
+        assertEquals(111, customFeeSchedule.num);
+
+        assertEquals("7.12.111", customFeeSchedule.toString());
+
+        SnapshotMatcher.expect(customFeeSchedule.toString()).toMatchSnapshot();
+    }
+
+    @Test
+    void getExchangeRatesFileIdForReturnsCorrectFileId() {
+        FileId defaultExchangeRates = FileId.getExchangeRatesFileIdFor(0, 0);
+        assertNotNull(defaultExchangeRates);
+        assertEquals(0, defaultExchangeRates.shard);
+        assertEquals(0, defaultExchangeRates.realm);
+        assertEquals(112, defaultExchangeRates.num);
+
+        int testShard = 3;
+        int testRealm = 9;
+        FileId customExchangeRates = FileId.getExchangeRatesFileIdFor(testShard, testRealm);
+        assertNotNull(customExchangeRates);
+        assertEquals(testShard, customExchangeRates.shard);
+        assertEquals(testRealm, customExchangeRates.realm);
+        assertEquals(112, customExchangeRates.num);
+
+        assertEquals("3.9.112", customExchangeRates.toString());
+
+        SnapshotMatcher.expect(customExchangeRates.toString()).toMatchSnapshot();
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
@@ -60,8 +60,8 @@ class FileIdTest {
         assertEquals(0, defaultAddressBook.realm);
         assertEquals(102, defaultAddressBook.num);
 
-        int testShard = 5;
-        int testRealm = 10;
+        long testShard = 5;
+        long testRealm = 10;
         FileId customAddressBook = FileId.getAddressBookFileIdFor(testShard, testRealm);
         assertNotNull(customAddressBook);
         assertEquals(testShard, customAddressBook.shard);
@@ -81,8 +81,8 @@ class FileIdTest {
         assertEquals(0, defaultFeeSchedule.realm);
         assertEquals(111, defaultFeeSchedule.num);
 
-        int testShard = 7;
-        int testRealm = 12;
+        long testShard = 7;
+        long testRealm = 12;
         FileId customFeeSchedule = FileId.getFeeScheduleFileIdFor(testShard, testRealm);
         assertNotNull(customFeeSchedule);
         assertEquals(testShard, customFeeSchedule.shard);
@@ -102,8 +102,8 @@ class FileIdTest {
         assertEquals(0, defaultExchangeRates.realm);
         assertEquals(112, defaultExchangeRates.num);
 
-        int testShard = 3;
-        int testRealm = 9;
+        long testShard = 3;
+        long testRealm = 9;
         FileId customExchangeRates = FileId.getExchangeRatesFileIdFor(testShard, testRealm);
         assertNotNull(customExchangeRates);
         assertEquals(testShard, customExchangeRates.shard);

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.snap
@@ -8,6 +8,21 @@ com.hedera.hashgraph.sdk.FileIdTest.fromSolidityAddress=[
 ]
 
 
+com.hedera.hashgraph.sdk.FileIdTest.getAddressBookFileIdForReturnsCorrectFileId=[
+  "5.10.102"
+]
+
+
+com.hedera.hashgraph.sdk.FileIdTest.getExchangeRatesFileIdForReturnsCorrectFileId=[
+  "3.9.112"
+]
+
+
+com.hedera.hashgraph.sdk.FileIdTest.getFeeScheduleFileIdForReturnsCorrectFileId=[
+  "7.12.111"
+]
+
+
 com.hedera.hashgraph.sdk.FileIdTest.shouldSerializeFromString=[
   "0.0.5005"
 ]

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -231,6 +233,7 @@ public class ClientIntegrationTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("`forMirrorNetwork with custom realm and shard")
     void testClientInitWithMirrorNetworkAnCustomRealmAndShard() throws Exception {
         var mirrorNetworkString = "testnet.mirrornode.hedera.com:443";

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -229,4 +229,19 @@ public class ClientIntegrationTest {
         assertThat(client.getNetwork()).isNotNull();
         assertThat(client.getNetwork()).isNotEmpty();
     }
+
+    @Test
+    @DisplayName("`forMirrorNetwork with custom realm and shard")
+    void testClientInitWithMirrorNetworkAnCustomRealmAndShard() throws Exception {
+        var mirrorNetworkString = "testnet.mirrornode.hedera.com:443";
+        int testRealm = 5;
+        int testShard = 10;
+        var client = Client.forMirrorNetwork(List.of(mirrorNetworkString), testRealm, testShard);
+        var mirrorNetwork = client.getMirrorNetwork();
+
+        assertThat(mirrorNetwork).hasSize(1);
+        assertThat(mirrorNetwork.get(0)).isEqualTo(mirrorNetworkString);
+        assertThat(client.getNetwork()).isNotNull();
+        assertThat(client.getNetwork()).isNotEmpty();
+    }
 }

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -232,13 +231,10 @@ public class ClientIntegrationTest {
     }
 
     @Test
-    @Disabled
     @DisplayName("`forMirrorNetwork with custom realm and shard")
     void testClientInitWithMirrorNetworkAnCustomRealmAndShard() throws Exception {
         var mirrorNetworkString = "testnet.mirrornode.hedera.com:443";
-        int testRealm = 5;
-        int testShard = 10;
-        var client = Client.forMirrorNetwork(List.of(mirrorNetworkString), testRealm, testShard);
+        var client = Client.forMirrorNetwork(List.of(mirrorNetworkString), 0, 0);
         var mirrorNetwork = client.getMirrorNetwork();
 
         assertThat(mirrorNetwork).hasSize(1);


### PR DESCRIPTION
**Description**:
Adds APIs for non-zero realm and shard AddressBook retrieving
Introduces new forMirrorNetwork method that handles non-zero realm and shard for specific FileId (non-zero AddressBook)

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2305

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
