### PR TITLE
build: run tests on module path

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.module.library")
-    id("org.hiero.gradle.feature.protobuf")
     id("org.hiero.gradle.feature.test-integration")
+    id("org.hiero.gradle.feature.protobuf")
     id("org.hiero.gradle.feature.publish-dependency-constraints")
 }
 

--- a/sdk/src/main/java/module-info.java
+++ b/sdk/src/main/java/module-info.java
@@ -19,4 +19,6 @@ module com.hedera.hashgraph.sdk {
     exports com.hedera.hashgraph.sdk.logger;
 
     opens com.hedera.hashgraph.sdk;
+    // for reflective access e.g. by com.fasterxml.jackson.databind
+    opens com.hedera.hashgraph.sdk.proto;
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.10" }
+plugins { id("org.hiero.gradle.build") version "0.4.0" }
 
 rootProject.name = "hedera-sdk-java"
 


### PR DESCRIPTION
**Description**:

Update _hiero-gradle-conventions_ to _0.4.0_ and by that run tests on the _module path_.

See https://github.com/hiero-ledger/hiero-consensus-node/pull/18922 for more details on how that works.