### PR TITLE
Hsm based transaction signing

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/HsmSigningExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/HsmSigningExample.java
@@ -30,13 +30,13 @@ public class HsmSigningExample {
      * Used to sign and pay for operations on Hedera.
      */
     private static final AccountId OPERATOR_ID =
-        AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+            AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
 
     /**
      * Operator's private key.
      */
     private static final PrivateKey OPERATOR_KEY =
-        PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+            PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
 
     /**
      * HEDERA_NETWORK defaults to testnet if not specified in dotenv file.
@@ -129,18 +129,18 @@ public class HsmSigningExample {
 
         // Create sender account
         TransactionResponse senderAccountResponse = new AccountCreateTransaction()
-            .setKeyWithoutAlias(senderKey.getPublicKey())
-            .setInitialBalance(Hbar.from(10))
-            .execute(client);
+                .setKeyWithoutAlias(senderKey.getPublicKey())
+                .setInitialBalance(Hbar.from(10))
+                .execute(client);
 
         TransactionReceipt senderAccountReceipt = senderAccountResponse.getReceipt(client);
         AccountId senderId = Objects.requireNonNull(senderAccountReceipt.accountId);
 
         // Create receiver account
         TransactionResponse receiverAccountResponse = new AccountCreateTransaction()
-            .setKeyWithoutAlias(receiverKey.getPublicKey())
-            .setInitialBalance(Hbar.from(1))
-            .execute(client);
+                .setKeyWithoutAlias(receiverKey.getPublicKey())
+                .setInitialBalance(Hbar.from(1))
+                .execute(client);
 
         TransactionReceipt receiverAccountReceipt = receiverAccountResponse.getReceipt(client);
         AccountId receiverId = Objects.requireNonNull(receiverAccountReceipt.accountId);
@@ -160,8 +160,8 @@ public class HsmSigningExample {
      * @param senderKey  The sender's private key (for HSM simulation)
      * @throws Exception If the transaction fails
      */
-    private static void singleNodeTransactionExample(Client client, AccountId senderId,
-                                                     AccountId receiverId, PrivateKey senderKey) throws Exception {
+    private static void singleNodeTransactionExample(
+            Client client, AccountId senderId, AccountId receiverId, PrivateKey senderKey) throws Exception {
         System.out.println("\n--- Single Node Transaction Example ---");
 
         // Step 1 - Create and prepare transfer transaction
@@ -171,11 +171,11 @@ public class HsmSigningExample {
 
         // Create transfer transaction
         TransferTransaction transferTx = new TransferTransaction()
-            .addHbarTransfer(senderId, Hbar.from(-1))
-            .addHbarTransfer(receiverId, Hbar.from(1))
-            .setNodeAccountIds(Arrays.asList(nodeAccountId))
-            .setTransactionId(TransactionId.generate(senderId))
-            .freezeWith(client);
+                .addHbarTransfer(senderId, Hbar.from(-1))
+                .addHbarTransfer(receiverId, Hbar.from(1))
+                .setNodeAccountIds(Arrays.asList(nodeAccountId))
+                .setTransactionId(TransactionId.generate(senderId))
+                .freezeWith(client);
 
         System.out.println("Transaction frozen. Node IDs: " + transferTx.getNodeAccountIds());
 
@@ -186,12 +186,12 @@ public class HsmSigningExample {
         // Sign with HSM for each entry
         for (int i = 0; i < signableList.size(); i++) {
             Transaction.SignableNodeTransactionBodyBytes signable = signableList.get(i);
-            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() +
-                " and transaction " + signable.getTransactionID());
+            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() + " and transaction "
+                    + signable.getTransactionID());
 
             byte[] signature = hsmSign(senderKey, signable.getBody());
-            transferTx = transferTx.addSignatureV2(senderKey.getPublicKey(), signature,
-                signable.getTransactionID(), signable.getNodeID());
+            transferTx = transferTx.addSignatureV2(
+                    senderKey.getPublicKey(), signature, signable.getTransactionID(), signable.getNodeID());
         }
 
         // Step 3 - Execute transaction and get receipt
@@ -211,8 +211,8 @@ public class HsmSigningExample {
      * @param senderKey The sender's private key (for HSM simulation)
      * @throws Exception If the transaction fails
      */
-    private static void multiNodeFileTransactionExample(Client client, AccountId senderId,
-                                                        PrivateKey senderKey) throws Exception {
+    private static void multiNodeFileTransactionExample(Client client, AccountId senderId, PrivateKey senderKey)
+            throws Exception {
         System.out.println("\n--- Multi-Node File Transaction Example ---");
 
         // Step 1 - Create initial file
@@ -221,11 +221,11 @@ public class HsmSigningExample {
 
         // Create file transaction
         FileCreateTransaction fileCreateTx = new FileCreateTransaction()
-            .setKeys(senderKey.getPublicKey())
-            .setContents(smallContents.getBytes())
-            .setMaxTransactionFee(Hbar.from(5))
-            .freezeWith(client)
-            .sign(senderKey);
+                .setKeys(senderKey.getPublicKey())
+                .setContents(smallContents.getBytes())
+                .setMaxTransactionFee(Hbar.from(5))
+                .freezeWith(client)
+                .sign(senderKey);
 
         TransactionResponse fileCreateResponse = fileCreateTx.execute(client);
         TransactionReceipt fileCreateReceipt = fileCreateResponse.getReceipt(client);
@@ -237,29 +237,29 @@ public class HsmSigningExample {
         String appendContent = "Additional content added via HSM signing.";
 
         FileAppendTransaction fileAppendTx = new FileAppendTransaction()
-            .setFileId(fileId)
-            .setContents(appendContent.getBytes())
-            .setMaxTransactionFee(Hbar.from(5))
-            .setTransactionId(TransactionId.generate(senderId))
-            .freezeWith(client);
+                .setFileId(fileId)
+                .setContents(appendContent.getBytes())
+                .setMaxTransactionFee(Hbar.from(5))
+                .setTransactionId(TransactionId.generate(senderId))
+                .freezeWith(client);
 
         System.out.println("File append transaction frozen. Node IDs: " + fileAppendTx.getNodeAccountIds());
 
         // Step 3 - Get signable bytes and sign with HSM for each node
         List<Transaction.SignableNodeTransactionBodyBytes> multiNodeSignableList =
-            fileAppendTx.getSignableNodeBodyBytesList();
+                fileAppendTx.getSignableNodeBodyBytesList();
 
         System.out.println("Got " + multiNodeSignableList.size() + " signable entries for file append");
 
         // Sign with HSM for each entry
         for (int i = 0; i < multiNodeSignableList.size(); i++) {
             Transaction.SignableNodeTransactionBodyBytes signable = multiNodeSignableList.get(i);
-            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() +
-                " and transaction " + signable.getTransactionID());
+            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() + " and transaction "
+                    + signable.getTransactionID());
 
             byte[] signature = hsmSign(senderKey, signable.getBody());
-            fileAppendTx = fileAppendTx.addSignatureV2(senderKey.getPublicKey(), signature,
-                signable.getTransactionID(), signable.getNodeID());
+            fileAppendTx = fileAppendTx.addSignatureV2(
+                    senderKey.getPublicKey(), signature, signable.getTransactionID(), signable.getNodeID());
         }
 
         // Step 4 - Execute transaction and verify results
@@ -270,9 +270,8 @@ public class HsmSigningExample {
         System.out.println("Multi-node file append transaction status: " + fileAppendReceipt.status);
 
         // Step 5 - Verify file contents
-        byte[] contents = new FileContentsQuery()
-            .setFileId(fileId)
-            .execute(client).toByteArray();
+        byte[] contents =
+                new FileContentsQuery().setFileId(fileId).execute(client).toByteArray();
 
         System.out.println("File content length according to FileContentsQuery: " + contents.length);
         System.out.println("File contents: " + new String(contents));

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/HsmSigningExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/HsmSigningExample.java
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.hashgraph.sdk.examples;
+
+import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.logger.LogLevel;
+import com.hedera.hashgraph.sdk.logger.Logger;
+import io.github.cdimascio.dotenv.Dotenv;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Hedera HSM Signing Example.
+ * <p>
+ * Demonstrates how to sign transactions using HSM (Hardware Security Module) simulation
+ * with both single node and multi-node scenarios. This example shows how to:
+ * 1. Get signable transaction body bytes for HSM signing
+ * 2. Add signatures back to transactions using AddSignatureV2
+ * 3. Handle both simple transfers and chunked file operations
+ */
+public class HsmSigningExample {
+    /*
+     * See .env.sample in the examples folder root for how to specify values below
+     * or set environment variables with the same names.
+     */
+
+    /**
+     * Operator's account ID.
+     * Used to sign and pay for operations on Hedera.
+     */
+    private static final AccountId OPERATOR_ID =
+        AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+
+    /**
+     * Operator's private key.
+     */
+    private static final PrivateKey OPERATOR_KEY =
+        PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+    /**
+     * HEDERA_NETWORK defaults to testnet if not specified in dotenv file.
+     * Network can be: localhost, testnet, previewnet or mainnet.
+     */
+    private static final String HEDERA_NETWORK = Dotenv.load().get("HEDERA_NETWORK", "testnet");
+
+    /**
+     * SDK_LOG_LEVEL defaults to SILENT if not specified in dotenv file.
+     * Log levels can be: TRACE, DEBUG, INFO, WARN, ERROR, SILENT.
+     */
+    private static final String SDK_LOG_LEVEL = Dotenv.load().get("SDK_LOG_LEVEL", "SILENT");
+
+    /**
+     * Main method to demonstrate HSM signing scenarios.
+     *
+     * @param args Command-line arguments (not used in this example)
+     */
+    public static void main(String[] args) {
+        System.out.println("HSM Signing Example Start!");
+
+        try {
+            /*
+             * Step 0:
+             * Create and configure SDK Client.
+             */
+            Client client = createClient();
+
+            /*
+             * Step 1:
+             * Generate keys and create test accounts.
+             */
+            AccountSetup accounts = setupTestAccounts(client);
+
+            /*
+             * Step 2:
+             * Demonstrate single node transaction signing.
+             */
+            singleNodeTransactionExample(client, accounts.senderId, accounts.receiverId, accounts.senderKey);
+
+            /*
+             * Step 3:
+             * Demonstrate multi-node multi-chunk transaction signing.
+             */
+            multiNodeFileTransactionExample(client, accounts.senderId, accounts.senderKey);
+
+            /*
+             * Clean up:
+             */
+            client.close();
+
+        } catch (Exception e) {
+            System.err.println("Example failed: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        System.out.println("HSM Signing Example Complete!");
+    }
+
+    /**
+     * Container class for account setup results.
+     */
+    private static class AccountSetup {
+        final AccountId senderId;
+        final AccountId receiverId;
+        final PrivateKey senderKey;
+        final PrivateKey receiverKey;
+
+        AccountSetup(AccountId senderId, AccountId receiverId, PrivateKey senderKey, PrivateKey receiverKey) {
+            this.senderId = senderId;
+            this.receiverId = receiverId;
+            this.senderKey = senderKey;
+            this.receiverKey = receiverKey;
+        }
+    }
+
+    /**
+     * Sets up test accounts for the example.
+     *
+     * @param client The Hedera network client
+     * @return AccountSetup containing the created accounts and keys
+     * @throws Exception If account creation fails
+     */
+    private static AccountSetup setupTestAccounts(Client client) throws Exception {
+        System.out.println("\n--- Setting up test accounts ---");
+
+        // Generate keys for sender and receiver
+        PrivateKey senderKey = PrivateKey.generateED25519();
+        PrivateKey receiverKey = PrivateKey.generateED25519();
+
+        // Create sender account
+        TransactionResponse senderAccountResponse = new AccountCreateTransaction()
+            .setKeyWithoutAlias(senderKey.getPublicKey())
+            .setInitialBalance(Hbar.from(10))
+            .execute(client);
+
+        TransactionReceipt senderAccountReceipt = senderAccountResponse.getReceipt(client);
+        AccountId senderId = Objects.requireNonNull(senderAccountReceipt.accountId);
+
+        // Create receiver account
+        TransactionResponse receiverAccountResponse = new AccountCreateTransaction()
+            .setKeyWithoutAlias(receiverKey.getPublicKey())
+            .setInitialBalance(Hbar.from(1))
+            .execute(client);
+
+        TransactionReceipt receiverAccountReceipt = receiverAccountResponse.getReceipt(client);
+        AccountId receiverId = Objects.requireNonNull(receiverAccountReceipt.accountId);
+
+        System.out.println("Created sender account: " + senderId);
+        System.out.println("Created receiver account: " + receiverId);
+
+        return new AccountSetup(senderId, receiverId, senderKey, receiverKey);
+    }
+
+    /**
+     * Demonstrates single node transaction signing with HSM simulation.
+     *
+     * @param client     The Hedera network client
+     * @param senderId   The sender account ID
+     * @param receiverId The receiver account ID
+     * @param senderKey  The sender's private key (for HSM simulation)
+     * @throws Exception If the transaction fails
+     */
+    private static void singleNodeTransactionExample(Client client, AccountId senderId,
+                                                     AccountId receiverId, PrivateKey senderKey) throws Exception {
+        System.out.println("\n--- Single Node Transaction Example ---");
+
+        // Step 1 - Create and prepare transfer transaction
+        // Get first node from network
+        Map<String, AccountId> network = client.getNetwork();
+        AccountId nodeAccountId = network.values().iterator().next();
+
+        // Create transfer transaction
+        TransferTransaction transferTx = new TransferTransaction()
+            .addHbarTransfer(senderId, Hbar.from(-1))
+            .addHbarTransfer(receiverId, Hbar.from(1))
+            .setNodeAccountIds(Arrays.asList(nodeAccountId))
+            .setTransactionId(TransactionId.generate(senderId))
+            .freezeWith(client);
+
+        System.out.println("Transaction frozen. Node IDs: " + transferTx.getNodeAccountIds());
+
+        // Step 2 - Get signable bytes and sign with HSM
+        List<Transaction.SignableNodeTransactionBodyBytes> signableList = transferTx.getSignableNodeBodyBytesList();
+        System.out.println("Got " + signableList.size() + " signable entries");
+
+        // Sign with HSM for each entry
+        for (int i = 0; i < signableList.size(); i++) {
+            Transaction.SignableNodeTransactionBodyBytes signable = signableList.get(i);
+            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() +
+                " and transaction " + signable.getTransactionID());
+
+            byte[] signature = hsmSign(senderKey, signable.getBody());
+            transferTx = transferTx.addSignatureV2(senderKey.getPublicKey(), signature,
+                signable.getTransactionID(), signable.getNodeID());
+        }
+
+        // Step 3 - Execute transaction and get receipt
+        System.out.println("Executing transaction...");
+        TransactionResponse transferResponse = transferTx.execute(client);
+        TransactionReceipt transferReceipt = transferResponse.getReceipt(client);
+
+        System.out.println("Single node transaction status: " + transferReceipt.status);
+    }
+
+    /**
+     * Demonstrates multi-node file transaction signing with HSM simulation.
+     * This example creates a large file append transaction that gets chunked across multiple nodes.
+     *
+     * @param client    The Hedera network client
+     * @param senderId  The sender account ID
+     * @param senderKey The sender's private key (for HSM simulation)
+     * @throws Exception If the transaction fails
+     */
+    private static void multiNodeFileTransactionExample(Client client, AccountId senderId,
+                                                        PrivateKey senderKey) throws Exception {
+        System.out.println("\n--- Multi-Node File Transaction Example ---");
+
+        // Step 1 - Create initial file
+        // Create smaller content for testing to avoid chunking issues
+        String smallContents = "Test file content for HSM signing example.";
+
+        // Create file transaction
+        FileCreateTransaction fileCreateTx = new FileCreateTransaction()
+            .setKeys(senderKey.getPublicKey())
+            .setContents(smallContents.getBytes())
+            .setMaxTransactionFee(Hbar.from(5))
+            .freezeWith(client)
+            .sign(senderKey);
+
+        TransactionResponse fileCreateResponse = fileCreateTx.execute(client);
+        TransactionReceipt fileCreateReceipt = fileCreateResponse.getReceipt(client);
+        FileId fileId = Objects.requireNonNull(fileCreateReceipt.fileId);
+
+        System.out.println("Created file with ID: " + fileId);
+
+        // Step 2 - Prepare file append transaction (using smaller content to avoid chunking for now)
+        String appendContent = "Additional content added via HSM signing.";
+
+        FileAppendTransaction fileAppendTx = new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(appendContent.getBytes())
+            .setMaxTransactionFee(Hbar.from(5))
+            .setTransactionId(TransactionId.generate(senderId))
+            .freezeWith(client);
+
+        System.out.println("File append transaction frozen. Node IDs: " + fileAppendTx.getNodeAccountIds());
+
+        // Step 3 - Get signable bytes and sign with HSM for each node
+        List<Transaction.SignableNodeTransactionBodyBytes> multiNodeSignableList =
+            fileAppendTx.getSignableNodeBodyBytesList();
+
+        System.out.println("Got " + multiNodeSignableList.size() + " signable entries for file append");
+
+        // Sign with HSM for each entry
+        for (int i = 0; i < multiNodeSignableList.size(); i++) {
+            Transaction.SignableNodeTransactionBodyBytes signable = multiNodeSignableList.get(i);
+            System.out.println("Signing entry " + i + " for node " + signable.getNodeID() +
+                " and transaction " + signable.getTransactionID());
+
+            byte[] signature = hsmSign(senderKey, signable.getBody());
+            fileAppendTx = fileAppendTx.addSignatureV2(senderKey.getPublicKey(), signature,
+                signable.getTransactionID(), signable.getNodeID());
+        }
+
+        // Step 4 - Execute transaction and verify results
+        System.out.println("Executing file append transaction...");
+        TransactionResponse fileAppendResponse = fileAppendTx.execute(client);
+        TransactionReceipt fileAppendReceipt = fileAppendResponse.getReceipt(client);
+
+        System.out.println("Multi-node file append transaction status: " + fileAppendReceipt.status);
+
+        // Step 5 - Verify file contents
+        byte[] contents = new FileContentsQuery()
+            .setFileId(fileId)
+            .execute(client).toByteArray();
+
+        System.out.println("File content length according to FileContentsQuery: " + contents.length);
+        System.out.println("File contents: " + new String(contents));
+    }
+
+    /**
+     * Simulates signing with an HSM (Hardware Security Module).
+     * In a real implementation, this would use actual HSM SDK logic.
+     *
+     * @param key       The private key (representing HSM key access)
+     * @param bodyBytes The transaction body bytes to sign
+     * @return The signature bytes
+     */
+    private static byte[] hsmSign(PrivateKey key, byte[] bodyBytes) {
+        // This is a placeholder that simulates HSM signing
+        // In a real HSM implementation, you would:
+        // 1. Send bodyBytes to the HSM
+        // 2. Use HSM APIs to sign with the stored private key
+        // 3. Return the signature from the HSM
+        return key.sign(bodyBytes);
+    }
+
+    /**
+     * Creates a Hedera network client using configuration from class-level constants.
+     *
+     * @return Configured Hedera network client
+     * @throws InterruptedException If there's an interruption during client creation
+     */
+    private static Client createClient() throws InterruptedException {
+        /*
+         * Step 1:
+         * Create a client for the specified network.
+         */
+        Client client = ClientHelper.forName(HEDERA_NETWORK);
+
+        /*
+         * Step 2:
+         * Set the operator (account paying for transactions).
+         */
+        client.setOperator(OPERATOR_ID, OPERATOR_KEY);
+
+        /*
+         * Step 3:
+         * Configure logging for the client.
+         */
+        client.setLogger(new Logger(LogLevel.valueOf(SDK_LOG_LEVEL)));
+
+        return client;
+    }
+}

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -12,15 +12,7 @@ import com.hedera.hashgraph.sdk.proto.TransactionList;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -390,110 +382,143 @@ public abstract class Transaction<T extends Transaction<T>>
                 .setTransactionFee(scheduled.getTransactionFee());
 
         return switch (scheduled.getDataCase()) {
-            case CONTRACTCALL -> new ContractExecuteTransaction(
-                    body.setContractCall(scheduled.getContractCall()).build());
-            case CONTRACTCREATEINSTANCE -> new ContractCreateTransaction(
-                    body.setContractCreateInstance(scheduled.getContractCreateInstance())
-                            .build());
-            case CONTRACTUPDATEINSTANCE -> new ContractUpdateTransaction(
-                    body.setContractUpdateInstance(scheduled.getContractUpdateInstance())
-                            .build());
-            case CONTRACTDELETEINSTANCE -> new ContractDeleteTransaction(
-                    body.setContractDeleteInstance(scheduled.getContractDeleteInstance())
-                            .build());
-            case CRYPTOAPPROVEALLOWANCE -> new AccountAllowanceApproveTransaction(
-                    body.setCryptoApproveAllowance(scheduled.getCryptoApproveAllowance())
-                            .build());
-            case CRYPTODELETEALLOWANCE -> new AccountAllowanceDeleteTransaction(
-                    body.setCryptoDeleteAllowance(scheduled.getCryptoDeleteAllowance())
-                            .build());
-            case CRYPTOCREATEACCOUNT -> new AccountCreateTransaction(
-                    body.setCryptoCreateAccount(scheduled.getCryptoCreateAccount())
-                            .build());
-            case CRYPTODELETE -> new AccountDeleteTransaction(
-                    body.setCryptoDelete(scheduled.getCryptoDelete()).build());
-            case CRYPTOTRANSFER -> new TransferTransaction(
-                    body.setCryptoTransfer(scheduled.getCryptoTransfer()).build());
-            case CRYPTOUPDATEACCOUNT -> new AccountUpdateTransaction(
-                    body.setCryptoUpdateAccount(scheduled.getCryptoUpdateAccount())
-                            .build());
-            case FILEAPPEND -> new FileAppendTransaction(
-                    body.setFileAppend(scheduled.getFileAppend()).build());
-            case FILECREATE -> new FileCreateTransaction(
-                    body.setFileCreate(scheduled.getFileCreate()).build());
-            case FILEDELETE -> new FileDeleteTransaction(
-                    body.setFileDelete(scheduled.getFileDelete()).build());
-            case FILEUPDATE -> new FileUpdateTransaction(
-                    body.setFileUpdate(scheduled.getFileUpdate()).build());
-            case NODECREATE -> new NodeCreateTransaction(
-                    body.setNodeCreate(scheduled.getNodeCreate()).build());
-            case NODEUPDATE -> new NodeUpdateTransaction(
-                    body.setNodeUpdate(scheduled.getNodeUpdate()).build());
-            case NODEDELETE -> new NodeDeleteTransaction(
-                    body.setNodeDelete(scheduled.getNodeDelete()).build());
-            case SYSTEMDELETE -> new SystemDeleteTransaction(
-                    body.setSystemDelete(scheduled.getSystemDelete()).build());
-            case SYSTEMUNDELETE -> new SystemUndeleteTransaction(
-                    body.setSystemUndelete(scheduled.getSystemUndelete()).build());
-            case FREEZE -> new FreezeTransaction(
-                    body.setFreeze(scheduled.getFreeze()).build());
-            case CONSENSUSCREATETOPIC -> new TopicCreateTransaction(
-                    body.setConsensusCreateTopic(scheduled.getConsensusCreateTopic())
-                            .build());
-            case CONSENSUSUPDATETOPIC -> new TopicUpdateTransaction(
-                    body.setConsensusUpdateTopic(scheduled.getConsensusUpdateTopic())
-                            .build());
-            case CONSENSUSDELETETOPIC -> new TopicDeleteTransaction(
-                    body.setConsensusDeleteTopic(scheduled.getConsensusDeleteTopic())
-                            .build());
-            case CONSENSUSSUBMITMESSAGE -> new TopicMessageSubmitTransaction(
-                    body.setConsensusSubmitMessage(scheduled.getConsensusSubmitMessage())
-                            .build());
-            case TOKENCREATION -> new TokenCreateTransaction(
-                    body.setTokenCreation(scheduled.getTokenCreation()).build());
-            case TOKENFREEZE -> new TokenFreezeTransaction(
-                    body.setTokenFreeze(scheduled.getTokenFreeze()).build());
-            case TOKENUNFREEZE -> new TokenUnfreezeTransaction(
-                    body.setTokenUnfreeze(scheduled.getTokenUnfreeze()).build());
-            case TOKENGRANTKYC -> new TokenGrantKycTransaction(
-                    body.setTokenGrantKyc(scheduled.getTokenGrantKyc()).build());
-            case TOKENREVOKEKYC -> new TokenRevokeKycTransaction(
-                    body.setTokenRevokeKyc(scheduled.getTokenRevokeKyc()).build());
-            case TOKENDELETION -> new TokenDeleteTransaction(
-                    body.setTokenDeletion(scheduled.getTokenDeletion()).build());
-            case TOKENUPDATE -> new TokenUpdateTransaction(
-                    body.setTokenUpdate(scheduled.getTokenUpdate()).build());
-            case TOKEN_UPDATE_NFTS -> new TokenUpdateNftsTransaction(
-                    body.setTokenUpdateNfts(scheduled.getTokenUpdateNfts()).build());
-            case TOKENMINT -> new TokenMintTransaction(
-                    body.setTokenMint(scheduled.getTokenMint()).build());
-            case TOKENBURN -> new TokenBurnTransaction(
-                    body.setTokenBurn(scheduled.getTokenBurn()).build());
-            case TOKENWIPE -> new TokenWipeTransaction(
-                    body.setTokenWipe(scheduled.getTokenWipe()).build());
-            case TOKENASSOCIATE -> new TokenAssociateTransaction(
-                    body.setTokenAssociate(scheduled.getTokenAssociate()).build());
-            case TOKENDISSOCIATE -> new TokenDissociateTransaction(
-                    body.setTokenDissociate(scheduled.getTokenDissociate()).build());
-            case TOKEN_FEE_SCHEDULE_UPDATE -> new TokenFeeScheduleUpdateTransaction(
-                    body.setTokenFeeScheduleUpdate(scheduled.getTokenFeeScheduleUpdate())
-                            .build());
-            case TOKEN_PAUSE -> new TokenPauseTransaction(
-                    body.setTokenPause(scheduled.getTokenPause()).build());
-            case TOKEN_UNPAUSE -> new TokenUnpauseTransaction(
-                    body.setTokenUnpause(scheduled.getTokenUnpause()).build());
-            case TOKENREJECT -> new TokenRejectTransaction(
-                    body.setTokenReject(scheduled.getTokenReject()).build());
-            case TOKENAIRDROP -> new TokenAirdropTransaction(
-                    body.setTokenAirdrop(scheduled.getTokenAirdrop()).build());
-            case TOKENCANCELAIRDROP -> new TokenCancelAirdropTransaction(
-                    body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
-                            .build());
-            case TOKENCLAIMAIRDROP -> new TokenClaimAirdropTransaction(
-                    body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
-                            .build());
-            case SCHEDULEDELETE -> new ScheduleDeleteTransaction(
-                    body.setScheduleDelete(scheduled.getScheduleDelete()).build());
+            case CONTRACTCALL ->
+                new ContractExecuteTransaction(
+                        body.setContractCall(scheduled.getContractCall()).build());
+            case CONTRACTCREATEINSTANCE ->
+                new ContractCreateTransaction(body.setContractCreateInstance(scheduled.getContractCreateInstance())
+                        .build());
+            case CONTRACTUPDATEINSTANCE ->
+                new ContractUpdateTransaction(body.setContractUpdateInstance(scheduled.getContractUpdateInstance())
+                        .build());
+            case CONTRACTDELETEINSTANCE ->
+                new ContractDeleteTransaction(body.setContractDeleteInstance(scheduled.getContractDeleteInstance())
+                        .build());
+            case CRYPTOAPPROVEALLOWANCE ->
+                new AccountAllowanceApproveTransaction(
+                        body.setCryptoApproveAllowance(scheduled.getCryptoApproveAllowance())
+                                .build());
+            case CRYPTODELETEALLOWANCE ->
+                new AccountAllowanceDeleteTransaction(
+                        body.setCryptoDeleteAllowance(scheduled.getCryptoDeleteAllowance())
+                                .build());
+            case CRYPTOCREATEACCOUNT ->
+                new AccountCreateTransaction(body.setCryptoCreateAccount(scheduled.getCryptoCreateAccount())
+                        .build());
+            case CRYPTODELETE ->
+                new AccountDeleteTransaction(
+                        body.setCryptoDelete(scheduled.getCryptoDelete()).build());
+            case CRYPTOTRANSFER ->
+                new TransferTransaction(
+                        body.setCryptoTransfer(scheduled.getCryptoTransfer()).build());
+            case CRYPTOUPDATEACCOUNT ->
+                new AccountUpdateTransaction(body.setCryptoUpdateAccount(scheduled.getCryptoUpdateAccount())
+                        .build());
+            case FILEAPPEND ->
+                new FileAppendTransaction(
+                        body.setFileAppend(scheduled.getFileAppend()).build());
+            case FILECREATE ->
+                new FileCreateTransaction(
+                        body.setFileCreate(scheduled.getFileCreate()).build());
+            case FILEDELETE ->
+                new FileDeleteTransaction(
+                        body.setFileDelete(scheduled.getFileDelete()).build());
+            case FILEUPDATE ->
+                new FileUpdateTransaction(
+                        body.setFileUpdate(scheduled.getFileUpdate()).build());
+            case NODECREATE ->
+                new NodeCreateTransaction(
+                        body.setNodeCreate(scheduled.getNodeCreate()).build());
+            case NODEUPDATE ->
+                new NodeUpdateTransaction(
+                        body.setNodeUpdate(scheduled.getNodeUpdate()).build());
+            case NODEDELETE ->
+                new NodeDeleteTransaction(
+                        body.setNodeDelete(scheduled.getNodeDelete()).build());
+            case SYSTEMDELETE ->
+                new SystemDeleteTransaction(
+                        body.setSystemDelete(scheduled.getSystemDelete()).build());
+            case SYSTEMUNDELETE ->
+                new SystemUndeleteTransaction(
+                        body.setSystemUndelete(scheduled.getSystemUndelete()).build());
+            case FREEZE ->
+                new FreezeTransaction(body.setFreeze(scheduled.getFreeze()).build());
+            case CONSENSUSCREATETOPIC ->
+                new TopicCreateTransaction(body.setConsensusCreateTopic(scheduled.getConsensusCreateTopic())
+                        .build());
+            case CONSENSUSUPDATETOPIC ->
+                new TopicUpdateTransaction(body.setConsensusUpdateTopic(scheduled.getConsensusUpdateTopic())
+                        .build());
+            case CONSENSUSDELETETOPIC ->
+                new TopicDeleteTransaction(body.setConsensusDeleteTopic(scheduled.getConsensusDeleteTopic())
+                        .build());
+            case CONSENSUSSUBMITMESSAGE ->
+                new TopicMessageSubmitTransaction(body.setConsensusSubmitMessage(scheduled.getConsensusSubmitMessage())
+                        .build());
+            case TOKENCREATION ->
+                new TokenCreateTransaction(
+                        body.setTokenCreation(scheduled.getTokenCreation()).build());
+            case TOKENFREEZE ->
+                new TokenFreezeTransaction(
+                        body.setTokenFreeze(scheduled.getTokenFreeze()).build());
+            case TOKENUNFREEZE ->
+                new TokenUnfreezeTransaction(
+                        body.setTokenUnfreeze(scheduled.getTokenUnfreeze()).build());
+            case TOKENGRANTKYC ->
+                new TokenGrantKycTransaction(
+                        body.setTokenGrantKyc(scheduled.getTokenGrantKyc()).build());
+            case TOKENREVOKEKYC ->
+                new TokenRevokeKycTransaction(
+                        body.setTokenRevokeKyc(scheduled.getTokenRevokeKyc()).build());
+            case TOKENDELETION ->
+                new TokenDeleteTransaction(
+                        body.setTokenDeletion(scheduled.getTokenDeletion()).build());
+            case TOKENUPDATE ->
+                new TokenUpdateTransaction(
+                        body.setTokenUpdate(scheduled.getTokenUpdate()).build());
+            case TOKEN_UPDATE_NFTS ->
+                new TokenUpdateNftsTransaction(
+                        body.setTokenUpdateNfts(scheduled.getTokenUpdateNfts()).build());
+            case TOKENMINT ->
+                new TokenMintTransaction(
+                        body.setTokenMint(scheduled.getTokenMint()).build());
+            case TOKENBURN ->
+                new TokenBurnTransaction(
+                        body.setTokenBurn(scheduled.getTokenBurn()).build());
+            case TOKENWIPE ->
+                new TokenWipeTransaction(
+                        body.setTokenWipe(scheduled.getTokenWipe()).build());
+            case TOKENASSOCIATE ->
+                new TokenAssociateTransaction(
+                        body.setTokenAssociate(scheduled.getTokenAssociate()).build());
+            case TOKENDISSOCIATE ->
+                new TokenDissociateTransaction(
+                        body.setTokenDissociate(scheduled.getTokenDissociate()).build());
+            case TOKEN_FEE_SCHEDULE_UPDATE ->
+                new TokenFeeScheduleUpdateTransaction(
+                        body.setTokenFeeScheduleUpdate(scheduled.getTokenFeeScheduleUpdate())
+                                .build());
+            case TOKEN_PAUSE ->
+                new TokenPauseTransaction(
+                        body.setTokenPause(scheduled.getTokenPause()).build());
+            case TOKEN_UNPAUSE ->
+                new TokenUnpauseTransaction(
+                        body.setTokenUnpause(scheduled.getTokenUnpause()).build());
+            case TOKENREJECT ->
+                new TokenRejectTransaction(
+                        body.setTokenReject(scheduled.getTokenReject()).build());
+            case TOKENAIRDROP ->
+                new TokenAirdropTransaction(
+                        body.setTokenAirdrop(scheduled.getTokenAirdrop()).build());
+            case TOKENCANCELAIRDROP ->
+                new TokenCancelAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
+                        .build());
+            case TOKENCLAIMAIRDROP ->
+                new TokenClaimAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
+                        .build());
+            case SCHEDULEDELETE ->
+                new ScheduleDeleteTransaction(
+                        body.setScheduleDelete(scheduled.getScheduleDelete()).build());
             default -> throw new IllegalStateException("schedulable transaction did not have a transaction set");
         };
     }
@@ -1495,5 +1520,133 @@ public abstract class Transaction<T extends Transaction<T>>
         }
 
         return 0;
+    }
+
+    public static class SignableNodeTransactionBodyBytes {
+        private AccountId nodeID;
+        private TransactionId transactionID;
+        private byte[] body;
+
+        public SignableNodeTransactionBodyBytes(AccountId nodeID, TransactionId transactionID, byte[] body) {
+            this.nodeID = nodeID;
+            this.transactionID = transactionID;
+            this.body = body;
+        }
+
+        public AccountId getNodeID() {
+            return nodeID;
+        }
+
+        public TransactionId getTransactionID() {
+            return transactionID;
+        }
+
+        public byte[] getBody() {
+            return body;
+        }
+    }
+
+    /**
+     * Returns a list of SignableNodeTransactionBodyBytes objects for each signed transaction in the transaction list.
+     * The NodeID represents the node that this transaction is signed for.
+     * The TransactionID is useful for signing chunked transactions like FileAppendTransaction,
+     * since they can have multiple transaction ids.
+     *
+     * @return List of SignableNodeTransactionBodyBytes
+     * @throws RuntimeException if transaction is not frozen or protobuf parsing fails
+     */
+    public List<SignableNodeTransactionBodyBytes> getSignableNodeBodyBytesList() {
+        if (!this.isFrozen()) {
+            throw new RuntimeException("Transaction is not frozen");
+        }
+
+        List<SignableNodeTransactionBodyBytes> signableNodeTransactionBodyBytesList = new ArrayList<>();
+
+        for (int i = 0; i < innerSignedTransactions.size(); i++) {
+            SignedTransaction signableNodeTransactionBodyBytes =
+                    innerSignedTransactions.get(i).build();
+
+            TransactionBody body;
+
+            try {
+                body = TransactionBody.parseFrom(signableNodeTransactionBodyBytes.getBodyBytes());
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException("Failed to parse transaction body", e);
+            }
+
+            AccountId nodeID = AccountId.fromProtobuf(body.getNodeAccountID());
+            TransactionId transactionID = TransactionId.fromProtobuf(body.getTransactionID());
+
+            signableNodeTransactionBodyBytesList.add(new SignableNodeTransactionBodyBytes(
+                    nodeID,
+                    transactionID,
+                    signableNodeTransactionBodyBytes.getBodyBytes().toByteArray()));
+        }
+
+        return signableNodeTransactionBodyBytesList;
+    }
+
+    /**
+     * Adds a signature to the transaction for a specific transaction id and node id.
+     * This is useful for signing chunked transactions like FileAppendTransaction,
+     * since they can have multiple transaction ids.
+     *
+     * @param publicKey The public key to add signature for
+     * @param signature The signature bytes
+     * @param transactionID The specific transaction ID to match
+     * @param nodeID The specific node ID to match
+     * @return The child transaction (this)
+     * @throws RuntimeException if unmarshaling fails or invalid signed transaction
+     */
+    public T addSignatureV2(PublicKey publicKey, byte[] signature, TransactionId transactionID, AccountId nodeID) {
+
+        if (innerSignedTransactions.isEmpty()) {
+            return (T) this;
+        }
+
+        transactionIds.setLocked(true);
+
+        for (int index = 0; index < innerSignedTransactions.size(); index++) {
+            SignedTransaction.Builder temp = innerSignedTransactions.get(index);
+
+            TransactionBody body;
+            try {
+                body = TransactionBody.parseFrom(temp.getBodyBytes());
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException("Failed to parse transaction body", e);
+            }
+
+            TransactionId bodyTxID = TransactionId.fromProtobuf(body.getTransactionID());
+            AccountId bodyNodeID = AccountId.fromProtobuf(body.getNodeAccountID());
+
+            // Check if the transaction id and node id match the input
+            if (bodyTxID.toString().equals(transactionID.toString())
+                    && bodyNodeID.toString().equals(nodeID.toString())) {
+
+                // Check if the signature is already in the signature map
+                boolean found = false;
+                SignatureMap.Builder sigMapBuilder = sigPairLists.get(index);
+
+                for (SignaturePair sig : sigMapBuilder.getSigPairList()) {
+                    if (Arrays.equals(sig.getPubKeyPrefix().toByteArray(), publicKey.toBytesRaw())) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found) {
+                    continue;
+                }
+
+                SignaturePair newSigPair = publicKey.toSignaturePairProtobuf(signature);
+                sigMapBuilder.addSigPair(newSigPair);
+
+                outerTransactions = new ArrayList<>(Collections.nCopies(nodeAccountIds.size(), null));
+                publicKeys.add(publicKey);
+                signers.add(null);
+            }
+        }
+
+        return (T) this;
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -382,143 +382,110 @@ public abstract class Transaction<T extends Transaction<T>>
                 .setTransactionFee(scheduled.getTransactionFee());
 
         return switch (scheduled.getDataCase()) {
-            case CONTRACTCALL ->
-                new ContractExecuteTransaction(
-                        body.setContractCall(scheduled.getContractCall()).build());
-            case CONTRACTCREATEINSTANCE ->
-                new ContractCreateTransaction(body.setContractCreateInstance(scheduled.getContractCreateInstance())
-                        .build());
-            case CONTRACTUPDATEINSTANCE ->
-                new ContractUpdateTransaction(body.setContractUpdateInstance(scheduled.getContractUpdateInstance())
-                        .build());
-            case CONTRACTDELETEINSTANCE ->
-                new ContractDeleteTransaction(body.setContractDeleteInstance(scheduled.getContractDeleteInstance())
-                        .build());
-            case CRYPTOAPPROVEALLOWANCE ->
-                new AccountAllowanceApproveTransaction(
-                        body.setCryptoApproveAllowance(scheduled.getCryptoApproveAllowance())
-                                .build());
-            case CRYPTODELETEALLOWANCE ->
-                new AccountAllowanceDeleteTransaction(
-                        body.setCryptoDeleteAllowance(scheduled.getCryptoDeleteAllowance())
-                                .build());
-            case CRYPTOCREATEACCOUNT ->
-                new AccountCreateTransaction(body.setCryptoCreateAccount(scheduled.getCryptoCreateAccount())
-                        .build());
-            case CRYPTODELETE ->
-                new AccountDeleteTransaction(
-                        body.setCryptoDelete(scheduled.getCryptoDelete()).build());
-            case CRYPTOTRANSFER ->
-                new TransferTransaction(
-                        body.setCryptoTransfer(scheduled.getCryptoTransfer()).build());
-            case CRYPTOUPDATEACCOUNT ->
-                new AccountUpdateTransaction(body.setCryptoUpdateAccount(scheduled.getCryptoUpdateAccount())
-                        .build());
-            case FILEAPPEND ->
-                new FileAppendTransaction(
-                        body.setFileAppend(scheduled.getFileAppend()).build());
-            case FILECREATE ->
-                new FileCreateTransaction(
-                        body.setFileCreate(scheduled.getFileCreate()).build());
-            case FILEDELETE ->
-                new FileDeleteTransaction(
-                        body.setFileDelete(scheduled.getFileDelete()).build());
-            case FILEUPDATE ->
-                new FileUpdateTransaction(
-                        body.setFileUpdate(scheduled.getFileUpdate()).build());
-            case NODECREATE ->
-                new NodeCreateTransaction(
-                        body.setNodeCreate(scheduled.getNodeCreate()).build());
-            case NODEUPDATE ->
-                new NodeUpdateTransaction(
-                        body.setNodeUpdate(scheduled.getNodeUpdate()).build());
-            case NODEDELETE ->
-                new NodeDeleteTransaction(
-                        body.setNodeDelete(scheduled.getNodeDelete()).build());
-            case SYSTEMDELETE ->
-                new SystemDeleteTransaction(
-                        body.setSystemDelete(scheduled.getSystemDelete()).build());
-            case SYSTEMUNDELETE ->
-                new SystemUndeleteTransaction(
-                        body.setSystemUndelete(scheduled.getSystemUndelete()).build());
-            case FREEZE ->
-                new FreezeTransaction(body.setFreeze(scheduled.getFreeze()).build());
-            case CONSENSUSCREATETOPIC ->
-                new TopicCreateTransaction(body.setConsensusCreateTopic(scheduled.getConsensusCreateTopic())
-                        .build());
-            case CONSENSUSUPDATETOPIC ->
-                new TopicUpdateTransaction(body.setConsensusUpdateTopic(scheduled.getConsensusUpdateTopic())
-                        .build());
-            case CONSENSUSDELETETOPIC ->
-                new TopicDeleteTransaction(body.setConsensusDeleteTopic(scheduled.getConsensusDeleteTopic())
-                        .build());
-            case CONSENSUSSUBMITMESSAGE ->
-                new TopicMessageSubmitTransaction(body.setConsensusSubmitMessage(scheduled.getConsensusSubmitMessage())
-                        .build());
-            case TOKENCREATION ->
-                new TokenCreateTransaction(
-                        body.setTokenCreation(scheduled.getTokenCreation()).build());
-            case TOKENFREEZE ->
-                new TokenFreezeTransaction(
-                        body.setTokenFreeze(scheduled.getTokenFreeze()).build());
-            case TOKENUNFREEZE ->
-                new TokenUnfreezeTransaction(
-                        body.setTokenUnfreeze(scheduled.getTokenUnfreeze()).build());
-            case TOKENGRANTKYC ->
-                new TokenGrantKycTransaction(
-                        body.setTokenGrantKyc(scheduled.getTokenGrantKyc()).build());
-            case TOKENREVOKEKYC ->
-                new TokenRevokeKycTransaction(
-                        body.setTokenRevokeKyc(scheduled.getTokenRevokeKyc()).build());
-            case TOKENDELETION ->
-                new TokenDeleteTransaction(
-                        body.setTokenDeletion(scheduled.getTokenDeletion()).build());
-            case TOKENUPDATE ->
-                new TokenUpdateTransaction(
-                        body.setTokenUpdate(scheduled.getTokenUpdate()).build());
-            case TOKEN_UPDATE_NFTS ->
-                new TokenUpdateNftsTransaction(
-                        body.setTokenUpdateNfts(scheduled.getTokenUpdateNfts()).build());
-            case TOKENMINT ->
-                new TokenMintTransaction(
-                        body.setTokenMint(scheduled.getTokenMint()).build());
-            case TOKENBURN ->
-                new TokenBurnTransaction(
-                        body.setTokenBurn(scheduled.getTokenBurn()).build());
-            case TOKENWIPE ->
-                new TokenWipeTransaction(
-                        body.setTokenWipe(scheduled.getTokenWipe()).build());
-            case TOKENASSOCIATE ->
-                new TokenAssociateTransaction(
-                        body.setTokenAssociate(scheduled.getTokenAssociate()).build());
-            case TOKENDISSOCIATE ->
-                new TokenDissociateTransaction(
-                        body.setTokenDissociate(scheduled.getTokenDissociate()).build());
-            case TOKEN_FEE_SCHEDULE_UPDATE ->
-                new TokenFeeScheduleUpdateTransaction(
-                        body.setTokenFeeScheduleUpdate(scheduled.getTokenFeeScheduleUpdate())
-                                .build());
-            case TOKEN_PAUSE ->
-                new TokenPauseTransaction(
-                        body.setTokenPause(scheduled.getTokenPause()).build());
-            case TOKEN_UNPAUSE ->
-                new TokenUnpauseTransaction(
-                        body.setTokenUnpause(scheduled.getTokenUnpause()).build());
-            case TOKENREJECT ->
-                new TokenRejectTransaction(
-                        body.setTokenReject(scheduled.getTokenReject()).build());
-            case TOKENAIRDROP ->
-                new TokenAirdropTransaction(
-                        body.setTokenAirdrop(scheduled.getTokenAirdrop()).build());
-            case TOKENCANCELAIRDROP ->
-                new TokenCancelAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
-                        .build());
-            case TOKENCLAIMAIRDROP ->
-                new TokenClaimAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
-                        .build());
-            case SCHEDULEDELETE ->
-                new ScheduleDeleteTransaction(
-                        body.setScheduleDelete(scheduled.getScheduleDelete()).build());
+            case CONTRACTCALL -> new ContractExecuteTransaction(
+                    body.setContractCall(scheduled.getContractCall()).build());
+            case CONTRACTCREATEINSTANCE -> new ContractCreateTransaction(
+                    body.setContractCreateInstance(scheduled.getContractCreateInstance())
+                            .build());
+            case CONTRACTUPDATEINSTANCE -> new ContractUpdateTransaction(
+                    body.setContractUpdateInstance(scheduled.getContractUpdateInstance())
+                            .build());
+            case CONTRACTDELETEINSTANCE -> new ContractDeleteTransaction(
+                    body.setContractDeleteInstance(scheduled.getContractDeleteInstance())
+                            .build());
+            case CRYPTOAPPROVEALLOWANCE -> new AccountAllowanceApproveTransaction(
+                    body.setCryptoApproveAllowance(scheduled.getCryptoApproveAllowance())
+                            .build());
+            case CRYPTODELETEALLOWANCE -> new AccountAllowanceDeleteTransaction(
+                    body.setCryptoDeleteAllowance(scheduled.getCryptoDeleteAllowance())
+                            .build());
+            case CRYPTOCREATEACCOUNT -> new AccountCreateTransaction(
+                    body.setCryptoCreateAccount(scheduled.getCryptoCreateAccount())
+                            .build());
+            case CRYPTODELETE -> new AccountDeleteTransaction(
+                    body.setCryptoDelete(scheduled.getCryptoDelete()).build());
+            case CRYPTOTRANSFER -> new TransferTransaction(
+                    body.setCryptoTransfer(scheduled.getCryptoTransfer()).build());
+            case CRYPTOUPDATEACCOUNT -> new AccountUpdateTransaction(
+                    body.setCryptoUpdateAccount(scheduled.getCryptoUpdateAccount())
+                            .build());
+            case FILEAPPEND -> new FileAppendTransaction(
+                    body.setFileAppend(scheduled.getFileAppend()).build());
+            case FILECREATE -> new FileCreateTransaction(
+                    body.setFileCreate(scheduled.getFileCreate()).build());
+            case FILEDELETE -> new FileDeleteTransaction(
+                    body.setFileDelete(scheduled.getFileDelete()).build());
+            case FILEUPDATE -> new FileUpdateTransaction(
+                    body.setFileUpdate(scheduled.getFileUpdate()).build());
+            case NODECREATE -> new NodeCreateTransaction(
+                    body.setNodeCreate(scheduled.getNodeCreate()).build());
+            case NODEUPDATE -> new NodeUpdateTransaction(
+                    body.setNodeUpdate(scheduled.getNodeUpdate()).build());
+            case NODEDELETE -> new NodeDeleteTransaction(
+                    body.setNodeDelete(scheduled.getNodeDelete()).build());
+            case SYSTEMDELETE -> new SystemDeleteTransaction(
+                    body.setSystemDelete(scheduled.getSystemDelete()).build());
+            case SYSTEMUNDELETE -> new SystemUndeleteTransaction(
+                    body.setSystemUndelete(scheduled.getSystemUndelete()).build());
+            case FREEZE -> new FreezeTransaction(
+                    body.setFreeze(scheduled.getFreeze()).build());
+            case CONSENSUSCREATETOPIC -> new TopicCreateTransaction(
+                    body.setConsensusCreateTopic(scheduled.getConsensusCreateTopic())
+                            .build());
+            case CONSENSUSUPDATETOPIC -> new TopicUpdateTransaction(
+                    body.setConsensusUpdateTopic(scheduled.getConsensusUpdateTopic())
+                            .build());
+            case CONSENSUSDELETETOPIC -> new TopicDeleteTransaction(
+                    body.setConsensusDeleteTopic(scheduled.getConsensusDeleteTopic())
+                            .build());
+            case CONSENSUSSUBMITMESSAGE -> new TopicMessageSubmitTransaction(
+                    body.setConsensusSubmitMessage(scheduled.getConsensusSubmitMessage())
+                            .build());
+            case TOKENCREATION -> new TokenCreateTransaction(
+                    body.setTokenCreation(scheduled.getTokenCreation()).build());
+            case TOKENFREEZE -> new TokenFreezeTransaction(
+                    body.setTokenFreeze(scheduled.getTokenFreeze()).build());
+            case TOKENUNFREEZE -> new TokenUnfreezeTransaction(
+                    body.setTokenUnfreeze(scheduled.getTokenUnfreeze()).build());
+            case TOKENGRANTKYC -> new TokenGrantKycTransaction(
+                    body.setTokenGrantKyc(scheduled.getTokenGrantKyc()).build());
+            case TOKENREVOKEKYC -> new TokenRevokeKycTransaction(
+                    body.setTokenRevokeKyc(scheduled.getTokenRevokeKyc()).build());
+            case TOKENDELETION -> new TokenDeleteTransaction(
+                    body.setTokenDeletion(scheduled.getTokenDeletion()).build());
+            case TOKENUPDATE -> new TokenUpdateTransaction(
+                    body.setTokenUpdate(scheduled.getTokenUpdate()).build());
+            case TOKEN_UPDATE_NFTS -> new TokenUpdateNftsTransaction(
+                    body.setTokenUpdateNfts(scheduled.getTokenUpdateNfts()).build());
+            case TOKENMINT -> new TokenMintTransaction(
+                    body.setTokenMint(scheduled.getTokenMint()).build());
+            case TOKENBURN -> new TokenBurnTransaction(
+                    body.setTokenBurn(scheduled.getTokenBurn()).build());
+            case TOKENWIPE -> new TokenWipeTransaction(
+                    body.setTokenWipe(scheduled.getTokenWipe()).build());
+            case TOKENASSOCIATE -> new TokenAssociateTransaction(
+                    body.setTokenAssociate(scheduled.getTokenAssociate()).build());
+            case TOKENDISSOCIATE -> new TokenDissociateTransaction(
+                    body.setTokenDissociate(scheduled.getTokenDissociate()).build());
+            case TOKEN_FEE_SCHEDULE_UPDATE -> new TokenFeeScheduleUpdateTransaction(
+                    body.setTokenFeeScheduleUpdate(scheduled.getTokenFeeScheduleUpdate())
+                            .build());
+            case TOKEN_PAUSE -> new TokenPauseTransaction(
+                    body.setTokenPause(scheduled.getTokenPause()).build());
+            case TOKEN_UNPAUSE -> new TokenUnpauseTransaction(
+                    body.setTokenUnpause(scheduled.getTokenUnpause()).build());
+            case TOKENREJECT -> new TokenRejectTransaction(
+                    body.setTokenReject(scheduled.getTokenReject()).build());
+            case TOKENAIRDROP -> new TokenAirdropTransaction(
+                    body.setTokenAirdrop(scheduled.getTokenAirdrop()).build());
+            case TOKENCANCELAIRDROP -> new TokenCancelAirdropTransaction(
+                    body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
+                            .build());
+            case TOKENCLAIMAIRDROP -> new TokenClaimAirdropTransaction(
+                    body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
+                            .build());
+            case SCHEDULEDELETE -> new ScheduleDeleteTransaction(
+                    body.setScheduleDelete(scheduled.getScheduleDelete()).build());
             default -> throw new IllegalStateException("schedulable transaction did not have a transaction set");
         };
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
@@ -3,6 +3,7 @@ package com.hedera.hashgraph.sdk;
 
 import static com.hedera.hashgraph.sdk.Transaction.fromBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.SignedTransaction;
@@ -11,18 +12,44 @@ import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class TransactionTest {
     private static final PrivateKey unusedPrivateKey = PrivateKey.fromString(
             "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
+    private static final PrivateKey mockPrivateKey = PrivateKey.fromString(
+            "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
     private static final List<AccountId> testNodeAccountIds =
             Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006"));
     private static final AccountId testAccountId = AccountId.fromString("0.0.5006");
     private static final Instant validStart = Instant.ofEpochSecond(1554158542);
+    private static final TransactionId testTransactionID = TransactionId.withValidStart(testAccountId, validStart);
+
+    private Client client;
+    // Additional test setup for new V2 methods
+    private FileId fileID;
+    private AccountId nodeAccountID1;
+    private AccountId nodeAccountID2;
+    private List<AccountId> nodeAccountIDs;
+    private byte[] mockSignature;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        client = Client.forTestnet();
+        client.setOperator(testAccountId, mockPrivateKey);
+
+        fileID = new FileId(3);
+        nodeAccountID1 = AccountId.fromString("0.0.3");
+        nodeAccountID2 = AccountId.fromString("0.0.4");
+        nodeAccountIDs = Arrays.asList(nodeAccountID1, nodeAccountID2);
+        mockSignature = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    }
 
     @Test
     void transactionFromBytesWorksWithProtobufTransactionBytes() throws InvalidProtocolBufferException {
@@ -272,5 +299,322 @@ public class TransactionTest {
 
         // The larger chunked transaction should be bigger than the small single-chunk transaction
         assertThat(largeSize).isGreaterThan(smallSize);
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Single Node Single Chunk")
+    void testAddSignatureV2SingleNodeSingleChunk() {
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents("test content".getBytes())
+                .setNodeAccountIds(Arrays.asList(nodeAccountID1))
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID1);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        assertThat(signatures).hasSize(1);
+        assertThat(signatures).containsKey(nodeAccountID1);
+
+        Map<PublicKey, byte[]> nodeSignatures = signatures.get(nodeAccountID1);
+        for (Map.Entry<PublicKey, byte[]> entry : nodeSignatures.entrySet()) {
+            assertThat(entry.getValue()).isEqualTo(mockSignature);
+        }
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Multiple Nodes Single Chunk")
+    void testAddSignatureV2MultipleNodesSingleChunk() {
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents("test content".getBytes())
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID1);
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID2);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        assertThat(signatures).hasSize(2);
+        assertThat(signatures).containsKey(nodeAccountID1);
+        assertThat(signatures).containsKey(nodeAccountID2);
+
+        for (AccountId nodeID : nodeAccountIDs) {
+            Map<PublicKey, byte[]> nodeSignatures = signatures.get(nodeID);
+            for (Map.Entry<PublicKey, byte[]> entry : nodeSignatures.entrySet()) {
+                assertThat(entry.getValue()).isEqualTo(mockSignature);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Multiple Nodes Multiple Chunks")
+    void testAddSignatureV2MultipleNodesMultipleChunks() {
+        byte[] content = new byte[2048];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) (i % 256);
+        }
+
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents(content)
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID1);
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID2);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        assertThat(signatures).hasSize(2);
+        assertThat(signatures).containsKey(nodeAccountID1);
+        assertThat(signatures).containsKey(nodeAccountID2);
+
+        for (AccountId nodeID : nodeAccountIDs) {
+            Map<PublicKey, byte[]> nodeSigs = signatures.get(nodeID);
+            assertThat(nodeSigs).hasSize(1);
+            for (Map.Entry<PublicKey, byte[]> entry : nodeSigs.entrySet()) {
+                assertThat(entry.getKey()).isNotNull();
+                assertThat(entry.getKey().toString())
+                        .isEqualTo(mockPrivateKey.getPublicKey().toString());
+                assertThat(entry.getValue()).isEqualTo(mockSignature);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Wrong Node ID")
+    void testAddSignatureV2WrongNodeID() {
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents("test content".getBytes())
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        AccountId invalidNodeID = AccountId.fromString("0.0.999");
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, invalidNodeID);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        assertThat(signatures).doesNotContainKey(invalidNodeID);
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Wrong Transaction ID")
+    void testAddSignatureV2WrongTransactionID() {
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents("test content".getBytes())
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        TransactionId invalidTxID = TransactionId.withValidStart(AccountId.fromString("0.0.999"), Instant.now());
+
+        transaction =
+                transaction.addSignatureV2(mockPrivateKey.getPublicKey(), mockSignature, invalidTxID, nodeAccountID1);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        if (signatures.containsKey(nodeAccountID1)) {
+            assertThat(signatures.get(nodeAccountID1)).doesNotContainKey(mockPrivateKey.getPublicKey());
+        }
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Adding Same Signature Twice")
+    void testAddSignatureV2SameSignatureTwice() {
+        var transaction = new FileAppendTransaction()
+                .setFileId(fileID)
+                .setContents("test content".getBytes())
+                .setNodeAccountIds(Arrays.asList(nodeAccountID1))
+                .setTransactionId(testTransactionID)
+                .setChunkSize(2048)
+                .freezeWith(client);
+
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID1);
+
+        transaction = transaction.addSignatureV2(
+                mockPrivateKey.getPublicKey(), mockSignature, testTransactionID, nodeAccountID1);
+
+        Map<AccountId, Map<PublicKey, byte[]>> signatures = transaction.getSignatures();
+        assertThat(signatures).hasSize(1);
+        assertThat(signatures).containsKey(nodeAccountID1);
+
+        Map<PublicKey, byte[]> nodeSigs = signatures.get(nodeAccountID1);
+        assertThat(nodeSigs).hasSize(1);
+        for (Map.Entry<PublicKey, byte[]> entry : nodeSigs.entrySet()) {
+            assertThat(entry.getValue()).isEqualTo(mockSignature);
+        }
+    }
+
+    @Test
+    @DisplayName("AddSignatureV2 - Empty Inner Signed Transactions")
+    void testAddSignatureV2WithEmptyInnerSignedTransactions() {
+        var tx = new FileAppendTransaction();
+
+        PrivateKey key = PrivateKey.generateED25519();
+
+        byte[] mockSig = {0, 1, 2, 3, 4};
+
+        AccountId nodeID = AccountId.fromString("0.0.3");
+        TransactionId testTxID = TransactionId.withValidStart(AccountId.fromString("0.0.5"), Instant.now());
+
+        var result = tx.addSignatureV2(key.getPublicKey(), mockSig, testTxID, nodeID);
+
+        assertThat(result).isSameAs(tx);
+    }
+
+    @Test
+    @DisplayName("GetSignableNodeBodyBytesList - Unfrozen Transaction")
+    void testGetSignableNodeBodyBytesListUnfrozen() {
+        var tx = new TransferTransaction();
+
+        assertThrows(RuntimeException.class, () -> {
+            tx.getSignableNodeBodyBytesList();
+        });
+    }
+
+    @Test
+    @DisplayName("GetSignableNodeBodyBytesList - Basic")
+    void testGetSignableNodeBodyBytesListBasic() {
+        var tx = new TransferTransaction()
+                .setNodeAccountIds(Arrays.asList(nodeAccountID1))
+                .setTransactionId(testTransactionID)
+                .addHbarTransfer(AccountId.fromString("0.0.2"), Hbar.from(-1))
+                .addHbarTransfer(AccountId.fromString("0.0.3"), Hbar.from(1))
+                .freezeWith(client);
+
+        List<Transaction.SignableNodeTransactionBodyBytes> list = tx.getSignableNodeBodyBytesList();
+        assertThat(list).isNotEmpty();
+        assertThat(list).hasSize(1); // Should have one entry for our single node
+
+        assertThat(list.get(0).getNodeID()).isEqualTo(nodeAccountID1);
+        assertThat(list.get(0).getTransactionID()).isEqualTo(testTransactionID);
+        assertThat(list.get(0).getBody()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("GetSignableNodeBodyBytesList - Contents Verification")
+    void testGetSignableNodeBodyBytesListContents() throws InvalidProtocolBufferException {
+        var tx = new TransferTransaction()
+                .setNodeAccountIds(Arrays.asList(nodeAccountID1))
+                .setTransactionId(testTransactionID)
+                .addHbarTransfer(AccountId.fromString("0.0.2"), Hbar.from(-1))
+                .addHbarTransfer(AccountId.fromString("0.0.3"), Hbar.from(1))
+                .freezeWith(client);
+
+        List<Transaction.SignableNodeTransactionBodyBytes> list = tx.getSignableNodeBodyBytesList();
+
+        TransactionBody body = TransactionBody.parseFrom(list.get(0).getBody());
+        assertThat(body.getCryptoTransfer()).isNotNull();
+        assertThat(AccountId.fromProtobuf(body.getNodeAccountID()).toString()).isEqualTo(nodeAccountID1.toString());
+        assertThat(TransactionId.fromProtobuf(body.getTransactionID()).toString())
+                .isEqualTo(testTransactionID.toString());
+    }
+
+    @Test
+    @DisplayName("GetSignableNodeBodyBytesList - Multiple Node IDs")
+    void testGetSignableNodeBodyBytesListMultipleNodeIDs() throws InvalidProtocolBufferException {
+        var tx = new TransferTransaction()
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .addHbarTransfer(AccountId.fromString("0.0.2"), Hbar.from(-1))
+                .addHbarTransfer(AccountId.fromString("0.0.3"), Hbar.from(1))
+                .freezeWith(client);
+
+        List<Transaction.SignableNodeTransactionBodyBytes> list = tx.getSignableNodeBodyBytesList();
+        assertThat(list).hasSize(2); // Should have two entries, one per node
+
+        for (int i = 0; i < nodeAccountIDs.size(); i++) {
+            AccountId nodeID = nodeAccountIDs.get(i);
+            assertThat(list.get(i).getNodeID()).isEqualTo(nodeID);
+            assertThat(list.get(i).getTransactionID()).isEqualTo(testTransactionID);
+            assertThat(list.get(i).getBody()).isNotEmpty();
+
+            // Verify body contents
+            TransactionBody body = TransactionBody.parseFrom(list.get(i).getBody());
+            assertThat(body.getCryptoTransfer()).isNotNull();
+            assertThat(AccountId.fromProtobuf(body.getNodeAccountID()).toString())
+                    .isEqualTo(nodeID.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("GetSignableNodeBodyBytesList - FileAppend Multiple Chunks")
+    void testGetSignableNodeBodyBytesListFileAppendMultipleChunks() throws InvalidProtocolBufferException {
+        byte[] content = new byte[4096];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) (i % 256);
+        }
+
+        var tx = new FileAppendTransaction()
+                .setNodeAccountIds(nodeAccountIDs)
+                .setTransactionId(testTransactionID)
+                .setFileId(new FileId(5))
+                .setContents(content)
+                .setChunkSize(2048) // Set small chunk size to force multiple chunks
+                .freezeWith(client);
+
+        List<Transaction.SignableNodeTransactionBodyBytes> list = tx.getSignableNodeBodyBytesList();
+        assertThat(list).hasSize(4); // Should have 4 entries: 2 nodes * 2 chunks
+
+        // Map to track transaction IDs per node
+        Map<String, Map<String, Boolean>> txIDsByNode = new HashMap<>();
+        for (AccountId nodeID : nodeAccountIDs) {
+            txIDsByNode.put(nodeID.toString(), new HashMap<>());
+        }
+
+        for (int i = 0; i < list.size(); i++) {
+            assertThat(nodeAccountIDs).contains(list.get(i).getNodeID());
+            assertThat(list.get(i).getTransactionID()).isNotNull();
+            assertThat(list.get(i).getBody()).isNotEmpty();
+
+            String nodeIDStr = list.get(i).getNodeID().toString();
+            String txIDStr = list.get(i).getTransactionID().toString();
+
+            // Each transaction ID should appear exactly once per node
+            assertThat(txIDsByNode.get(nodeIDStr).containsKey(txIDStr))
+                    .as("Duplicate transaction ID found for the same node")
+                    .isFalse();
+            txIDsByNode.get(nodeIDStr).put(txIDStr, true);
+
+            TransactionBody body = TransactionBody.parseFrom(list.get(i).getBody());
+            assertThat(body.getFileAppend()).isNotNull();
+            assertThat(AccountId.fromProtobuf(body.getNodeAccountID()).toString())
+                    .isEqualTo(list.get(i).getNodeID().toString());
+        }
+
+        // Verify each node has the same number of unique transaction IDs
+        for (AccountId nodeID : nodeAccountIDs) {
+            assertThat(txIDsByNode.get(nodeID.toString()))
+                    .as("Each node should have exactly 2 unique transaction IDs")
+                    .hasSize(2);
+        }
+
+        // Verify that all nodes have the same set of transaction IDs
+        Map<String, Boolean> firstNodeTxIDs = txIDsByNode.get(nodeAccountID1.toString());
+        for (int i = 1; i < nodeAccountIDs.size(); i++) {
+            Map<String, Boolean> nodeTxIDs =
+                    txIDsByNode.get(nodeAccountIDs.get(i).toString());
+            for (String txID : firstNodeTxIDs.keySet()) {
+                assertThat(nodeTxIDs.containsKey(txID))
+                        .as("All nodes should have the same set of transaction IDs")
+                        .isTrue();
+            }
+        }
     }
 }


### PR DESCRIPTION
**Description**:
Currently, in the Java SDK, PrivateKey.sign(transaction.toBytes()) does not produce a network-valid signature because it signs the entire transaction, not the canonical bodyBytes.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #
https://github.com/hiero-ledger/hiero-sdk-java/issues/2350
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
