### PR TITLE
build: change publishing to use maven central publishing portal

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -129,4 +129,4 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: ./gradlew releaseMavenCentral -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --scan --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,16 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
-    id("org.hiero.gradle.base.lifecycle")
+    id("org.hiero.gradle.feature.publish-maven-central-aggregation")
     id("org.hiero.gradle.report.code-coverage")
     id("org.hiero.gradle.check.spotless")
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
 dependencies {
+    published(project(":sdk"))
+    published(project(":sdk-full"))
+
     implementation(project(":sdk"))
     implementation(project(":tck"))
     implementation("io.grpc:grpc-protobuf")
 }
+
+// Separate publishing from the coverage aggregation as 'sdk' and 'sdk-full'
+// cannot both exist on the compile/test path
+configurations.implementation { setExtendsFrom(extendsFrom.filter { it.name != "published" }) }
 
 tasks.testCodeCoverageReport {
     // Integrate coverage data from integration tests into the report


### PR DESCRIPTION
**Description**:


⚠️ Only merge after we made switched the publishing mechanism on the Maven Central side.

For more details see: https://github.com/hiero-ledger/hiero-consensus-node/pull/19567

**Related issue(s)**:

https://github.com/hiero-ledger/hiero-consensus-node/pull/19567
