### PR TITLE
chore: update hiero-gradle-conventions to v0.4.5

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.4.1" }
+plugins { id("org.hiero.gradle.build") version "0.4.5" }
 
 rootProject.name = "hedera-sdk-java"
 


### PR DESCRIPTION
**Description**:

Update hiero-gradle-conventions to v0.4.5 to fix issue with OSSRH URL in Maven Central.

**Related Issue(s)**:

Fixes #2394
