### PR TITLE
fix: reties on topic unsubscribe

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -320,11 +320,8 @@ public final class TopicMessageQuery {
 
             @Override
             public void onError(Throwable t) {
-                if (attempt >= maxAttempts || !retryHandler.test(t)) {
+                if (attempt >= maxAttempts || !retryHandler.test(t) || cancelledByClient.get()) {
                     errorHandler.accept(t, null);
-                    return;
-                }
-                if (cancelledByClient.get()) {
                     return;
                 }
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -399,9 +399,9 @@ class TopicMessageQueryTest {
         });
         subscribeToMirror(received::add);
         Assertions.assertThat(received)
-            .hasSize(1)
-            .extracting(t -> t.sequenceNumber)
-            .containsExactly(1L);
+                .hasSize(1)
+                .extracting(t -> t.sequenceNumber)
+                .containsExactly(1L);
         assertThat(errors).isEmpty();
     }
 
@@ -436,9 +436,9 @@ class TopicMessageQueryTest {
 
         assertThat(errors).isEmpty();
         Assertions.assertThat(received)
-            .hasSize(1)
-            .extracting(t -> t.sequenceNumber)
-            .containsExactly(1L);
+                .hasSize(1)
+                .extracting(t -> t.sequenceNumber)
+                .containsExactly(1L);
 
         secondHandle.unsubscribe();
     }


### PR DESCRIPTION
**Description**:
Disable retries when customer unsubscribes from a topic.

**Related issue(s):**
Fixes https://github.com/hiero-ledger/hiero-sdk-java/issues/2453

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
