### PR TITLE
fix: correct protobuf typo in FileInfo javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
@@ -68,7 +68,7 @@ public final class FileInfo {
     }
 
     /**
-     * Create a file info object from a ptotobuf.
+     * Create a file info object from a protobuf.
      *
      * @param fileInfo                  the protobuf
      * @return                          the new file info object


### PR DESCRIPTION
## Summary

Fixed a typo in the FileInfo Javadoc comment.

## Changes

- Updated "ptotobuf" to "protobuf" in FileInfo.java documentation.

## Testing

- Documentation-only change, no functional code changes.