### PR TITLE
docs: fix typo in README.md ("guidelies" -> "guidelines")

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on d
 
 ## About Users and Maintainers
 
-Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
+Users and Maintainers guidelines are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes the typo reported in #2821: `guidelies` → `guidelines` on line 49 of README.md.

Note: this commit includes a DCO sign-off (`-s`) but is not GPG-signed (`-S`) because no GPG key is registered on the account yet. Please enable commit signing (or rebase-and-sign locally) if the merge check requires a verified signature.

Closes #2821