### PR TITLE
chore: update solo version to 0.65.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@531a2b283ca4912df537d64bf89da0f6be4c2574 # v0.22.0
         with:
           installMirrorNode: true
-          soloVersion: v0.65.0
+          soloVersion: v0.65.1
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 
@@ -171,7 +171,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@531a2b283ca4912df537d64bf89da0f6be4c2574 # v0.22.0
         with:
           installMirrorNode: true
-          soloVersion: v0.65.0
+          soloVersion: v0.65.1
           dualMode: true
           hieroVersion: v0.73.0
           mirrorNodeVersion: v0.153.0
@@ -229,7 +229,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@531a2b283ca4912df537d64bf89da0f6be4c2574 # v0.22.0
         with:
           installMirrorNode: true
-          soloVersion: v0.65.0
+          soloVersion: v0.65.1
           mirrorNodeVersion: v0.153.0
           hieroVersion: v0.73.0
 


### PR DESCRIPTION
## Summary
- Bumps the pinned Solo CLI version used in CI (`hiero-solo-action` `soloVersion` input) from `v0.65.0` to `v0.65.1` across all three jobs in `build.yml` that use it.