### PR TITLE
docs: fix typo in FileInfo protobuf documentation

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
@@ -68,7 +68,7 @@ public final class FileInfo {
     }
 
     /**
-     * Create a file info object from a ptotobuf.
+     * Create a file info object from a protobuf.
      *
      * @param fileInfo                  the protobuf
      * @return                          the new file info object


### PR DESCRIPTION
**Description**:

Fix typo in FileInfo JavaDoc comment.

* Change "ptotobuf" to "protobuf" in FileInfo documentation.

**Related issue(s)**:
Fixes #2822

N/A

**Notes for reviewer**:

This is a documentation-only change. No code changes were made.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)