### PR TITLE
docs: fix typo guidelies → guidelines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on d
 
 ## About Users and Maintainers
 
-Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
+Users and Maintainers guidelines are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes #2821

Fixes a simple typo on line 49 of README.md: `guidelies` → `guidelines`.