### PR TITLE
Fix typo: guidelies -> guidelines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on d
 
 ## About Users and Maintainers
 
-Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles/roles-and-groups.md).**
+Users and Maintainers guidelines are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles/roles-and-groups.md).**
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes typo in README.md line 49: `guidelies` -> `guidelines`

Closes #2821