### PR TITLE
docs: fix typo in TokenNftAllowance

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftAllowance.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftAllowance.java
@@ -82,7 +82,7 @@ public class TokenNftAllowance {
     /**
      * Create a copy of a nft token allowance object.
      *
-     * @param allowance                 the nft token allowance to copj
+     * @param allowance                 the nft token allowance to copy
      * @return                          a new copy
      */
     static TokenNftAllowance copyFrom(TokenNftAllowance allowance) {


### PR DESCRIPTION
Fixes #2910

Corrects the `copj` typo in the TokenNftAllowance.copyFrom Javadoc parameter description.

Checks: `./gradlew --no-daemon :sdk:spotlessCheck :sdk:test`