### PR TITLE
ci: harden workflow token permissions and validate Gradle wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ defaults:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   LC_ALL: C.UTF-8

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "Gradle Wrapper Validation"
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+  pull_request:
+    branches:
+      - main
+      - develop
+      - release/*
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validate Gradle Wrapper
+    runs-on: hiero-client-sdk-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,9 +12,6 @@ defaults:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  pages: write
 
 env:
   LC_ALL: C.UTF-8
@@ -23,6 +20,10 @@ jobs:
   publish:
     name: Publish
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/pr-formatting.yml
+++ b/.github/workflows/pr-formatting.yml
@@ -14,7 +14,6 @@ defaults:
 
 permissions:
   contents: read
-  statuses: write
 
 concurrency:
   group: pr-formatting-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -24,6 +23,9 @@ jobs:
   title-check:
     name: Title Check
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -18,7 +18,6 @@ defaults:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   LC_ALL: C.UTF-8
@@ -74,6 +73,9 @@ jobs:
   maven-central:
     name: Publish to Maven Central
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: read
+      packages: write
     needs:
       # This needs clause exists solely to provide a dependency on the previous step. This publish step will not occur
       # until the validate-release step completes successfully.

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -9,12 +9,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   snyk:
     name: Snyk Monitor
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0


### PR DESCRIPTION
**Description**:

Tighten the `GITHUB_TOKEN` permissions of every workflow and add Gradle wrapper validation, to address the two open OpenSSF Scorecard findings on this repo (Token-Permissions currently scores 0 because several workflows declare write scopes at the top level; Binary-Artifacts scores 9 because the checked-in `gradle-wrapper.jar` is not verified by a wrapper-validation workflow).

* Restrict every workflow to `contents: read` at the top level and grant write scopes only to the jobs that use them
* Drop the unused `packages: write` scope from `build.yml` and `pages.yml`
* Add a `Gradle Wrapper Validation` workflow using `gradle/actions/wrapper-validation`

**Changes**

_Token-Permissions_

| Workflow | Before (top level) | After |
| --- | --- | --- |
| `build.yml` | `contents: read`, `packages: write` | `contents: read` (scope dropped, see note below) |
| `pages.yml` | `contents: read`, `packages: write`, `id-token: write`, `pages: write` | top level `contents: read`; `publish` job: `contents: read`, `id-token: write`, `pages: write` |
| `pr-formatting.yml` | `contents: read`, `statuses: write` | top level `contents: read`; `title-check` job: `contents: read`, `statuses: write` |
| `snyk-monitor.yml` | `contents: read`, `security-events: write` | top level `contents: read`; `snyk` job: `contents: read`, `security-events: write` |
| `release-artifacts.yml` | `contents: read`, `packages: write` | top level `contents: read`; `maven-central` job: `contents: read`, `packages: write` |

`packages: write` was removed from `build.yml` and `pages.yml` rather than moved: no Gradle configuration in this repo publishes to GitHub Packages, and the same jobs already run successfully on read-only tokens for Dependabot and fork pull requests (e.g. #2911). It was kept at job level for the `maven-central` release job because that path cannot be exercised from a pull request; it can be dropped there too if maintainers agree it is unused.

_Binary-Artifacts_

* New `.github/workflows/gradle-wrapper-validation.yml` runs `gradle/actions/wrapper-validation` on pushes to `main`/`develop`/`release/*` and on pull requests, following the same structure (SPDX header, `hiero-client-sdk-linux-medium` runner, harden-runner, SHA-pinned actions) as the existing workflows. Scorecard exempts `gradle/wrapper/gradle-wrapper.jar` once this workflow has a successful run on the latest `main` commit.

| Check | Before | After (local `scorecard --local`) |
| --- | --- | --- |
| Token-Permissions | 0 | 10 |
| Dangerous-Workflow | 10 | 10 |
| Pinned-Dependencies | 9 | 9 |
| Binary-Artifacts | 9 | 9 locally; the wrapper-validation exemption is only evaluated against workflow runs on `main` |

**Intentionally not changed**

* `npm install -g snyk` in `snyk-monitor.yml` is the one remaining Pinned-Dependencies finding. It is a global CLI install (no lockfile to switch to `npm ci`), so it is left as is.
* No CodeQL workflow was added: code scanning is already enabled for this repo through GitHub's default setup (`Analyze (actions|javascript-typescript|python)` checks on pushes to `main` and on pull requests opened from branches in this repository), which Scorecard already credits under SAST. An advanced-setup CodeQL workflow cannot upload results while default setup is enabled.
* `.github/workflows/disabled/*` are not read by GitHub Actions or Scorecard and are left untouched.

**Related issue(s)**:

N/A

**Notes for reviewer**:

* `actionlint` on all touched workflows reports only the pre-existing warnings (the self-hosted runner label and SC2086 in existing scripts), identical to `main`.
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` run before and after; results in the table above.
* The `Gradle Wrapper Validation` check on this PR is the first run of the new workflow.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

