### PR TITLE
docs: fix Javadoc for CustomFractionalFee getMax

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/CustomFractionalFee.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/CustomFractionalFee.java
@@ -109,7 +109,7 @@ public class CustomFractionalFee extends CustomFeeBase<CustomFractionalFee> {
     }
 
     /**
-     * Extract the fee amount.
+     * Extract the maximum fee amount.
      *
      * @return the fee amount
      */


### PR DESCRIPTION
Fix the Javadoc of the `getMax` method in `CustomFractionalFee` to state that it extracts the maximum fee amount.

Fixes #2916