### PR TITLE
docs: fix CustomFractionalFee getMax javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/CustomFractionalFee.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/CustomFractionalFee.java
@@ -109,7 +109,7 @@ public class CustomFractionalFee extends CustomFeeBase<CustomFractionalFee> {
     }
 
     /**
-     * Extract the fee amount.
+     * Extract the maximum fee amount.
      *
      * @return the fee amount
      */


### PR DESCRIPTION
## Summary

Fix the Javadoc for `CustomFractionalFee#getMax`.

## Changes

* Updated the Javadoc description to specify that `getMax()` extracts the maximum fee amount.

## Testing

* `./gradlew :sdk:javadoc`
* `./gradlew :sdk:qualityCheck`
* `./gradlew :sdk:test`
* 1,641 tests passing, 2 pending

Fixes #2916
