### PR TITLE
chore: Converted TCK response classes to records

### DIFF
--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -37,10 +35,7 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
     // although the tck driver would not call these methods in such way
     private final Map<String, Method> methodMap;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            // TODO: Should remove the below visiblity once dtos are change to use record.
-            .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
-            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     protected AbstractJSONRPC2Service() {
         methodMap = new HashMap<>();

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/ContractService.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/ContractService.java
@@ -73,8 +73,8 @@ public class ContractService extends AbstractJSONRPC2Service {
                 result.gasUsed,
                 result.logs,
                 result.gas,
-                result.hbarAmount,
-                result.senderAccountId,
+                result.hbarAmount.toString(),
+                result.senderAccountId != null ? result.senderAccountId.toString() : null,
                 result.signerNonce,
                 Hex.toHexString(result.asBytes()));
     }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/KeyService.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/KeyService.java
@@ -14,6 +14,8 @@ import com.hedera.hashgraph.tck.methods.sdk.param.GenerateKeyParams;
 import com.hedera.hashgraph.tck.methods.sdk.response.GenerateKeyResponse;
 import com.hedera.hashgraph.tck.util.KeyUtils;
 import com.hedera.hashgraph.tck.util.KeyUtils.KeyType;
+import java.util.ArrayList;
+import java.util.List;
 import org.bouncycastle.util.encoders.Hex;
 
 @JSONRPC2Service
@@ -57,13 +59,12 @@ public class KeyService extends AbstractJSONRPC2Service {
                     "invalid request: threshold is required for generating a ThresholdKey type.");
         }
 
-        GenerateKeyResponse response = new GenerateKeyResponse();
-        response.setKey(processKeyRecursively(params, response, false));
-        return response;
+        List<String> privateKeys = new ArrayList<>();
+        String key = processKeyRecursively(params, privateKeys, false);
+        return new GenerateKeyResponse(key, privateKeys);
     }
 
-    private String processKeyRecursively(
-            final GenerateKeyParams params, final GenerateKeyResponse response, boolean isList)
+    private String processKeyRecursively(final GenerateKeyParams params, final List<String> privateKeys, boolean isList)
             throws InvalidJSONRPC2RequestException, InvalidProtocolBufferException {
         String privateKeyString;
         PrivateKey privateKey;
@@ -73,7 +74,7 @@ public class KeyService extends AbstractJSONRPC2Service {
                         ? PrivateKey.generateED25519().toStringDER()
                         : PrivateKey.generateECDSA().toStringDER();
                 if (isList) {
-                    response.getPrivateKeys().add(privateKeyString);
+                    privateKeys.add(privateKeyString);
                 }
 
                 return privateKeyString;
@@ -88,7 +89,7 @@ public class KeyService extends AbstractJSONRPC2Service {
                         ? PrivateKey.generateED25519()
                         : PrivateKey.generateECDSA();
                 if (isList) {
-                    response.getPrivateKeys().add(privateKey.toStringDER());
+                    privateKeys.add(privateKey.toStringDER());
                 }
 
                 return privateKey.getPublicKey().toStringDER();
@@ -97,7 +98,7 @@ public class KeyService extends AbstractJSONRPC2Service {
                 KeyList keyList = new KeyList();
                 params.getKeys().get().forEach(keyParams -> {
                     try {
-                        keyList.add(KeyUtils.getKeyFromString(processKeyRecursively(keyParams, response, true)));
+                        keyList.add(KeyUtils.getKeyFromString(processKeyRecursively(keyParams, privateKeys, true)));
                     } catch (Exception e) {
                         throw new IllegalArgumentException(e);
                     }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountAllowanceResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountAllowanceResponse.java
@@ -3,4 +3,9 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represents the accountAllowance response.
+ *
+ * @param status the status of the submitted transaction
+ */
 public record AccountAllowanceResponse(Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountAllowanceResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountAllowanceResponse.java
@@ -2,9 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.Data;
 
-@Data
-public class AccountAllowanceResponse {
-    private final Status status;
-}
+public record AccountAllowanceResponse(Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountBalanceResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountBalanceResponse.java
@@ -4,19 +4,8 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 import com.hedera.hashgraph.sdk.TokenId;
 import java.util.Map;
 import javax.annotation.Nonnegative;
-import lombok.Data;
 
-@Data
-public class AccountBalanceResponse {
-
-    /**
-     * The Hbar balance of the account
-     */
-    @Nonnegative
-    public final String hbars;
-
-    public final Map<TokenId, Long> tokenBalances;
-
-    @Nonnegative
-    public final Map<TokenId, Integer> tokenDecimals;
-}
+public record AccountBalanceResponse(
+        @Nonnegative String hbars,
+        Map<TokenId, Long> tokenBalances,
+        @Nonnegative Map<TokenId, Integer> tokenDecimals) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountBalanceResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountBalanceResponse.java
@@ -5,6 +5,13 @@ import com.hedera.hashgraph.sdk.TokenId;
 import java.util.Map;
 import javax.annotation.Nonnegative;
 
+/**
+ * Represent accountBalance response.
+ *
+ * @param hbars the hbar balance of the account in tinybars
+ * @param tokenBalances a map of token IDs to the balances
+ * @param tokenDecimals a map of token IDs to the decimal places
+ */
 public record AccountBalanceResponse(
         @Nonnegative String hbars,
         Map<TokenId, Long> tokenBalances,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountResponse.java
@@ -3,4 +3,11 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent response for account related transactions.
+ *
+ * @param accountId the ID of the account
+ * @param status the status of the submitted transaction
+ * @param transactionId the ID of the transaction
+ */
 public record AccountResponse(String accountId, Status status, String transactionId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AccountResponse.java
@@ -2,11 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.Data;
 
-@Data
-public class AccountResponse {
-    private final String accountId;
-    private final Status status;
-    private final String transactionId;
-}
+public record AccountResponse(String accountId, Status status, String transactionId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AddressBookResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AddressBookResponse.java
@@ -5,61 +5,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
 
-@Data
-public class AddressBookResponse {
-    private final List<NodeAddress> nodeAddresses = new ArrayList<>();
-
-    @Getter
-    @AllArgsConstructor
-    public static class NodeAddress {
-        /**
-         * The RSA public key of the node.
-         */
-        @Nullable
-        String publicKey;
-        /**
-         * The account to be paid for queries and transactions sent to this node.
-         */
-        @Nullable
-        String accountId;
-        /**
-         * A non-sequential identifier for the node.
-         */
-        long nodeId;
-        /**
-         * A hash of the X509 cert used for gRPC traffic to this node.
-         */
-        @Nullable
-        String certHash;
-        /**
-         * A node's service IP addresses and ports.
-         */
-        List<Endpoint> serviceEndpoints;
-        /**
-         * A description of the node, with UTF-8 encoding up to 100 bytes.
-         */
-        @Nullable
-        String description;
-        /**
-         * The amount of tinybars staked to the node.
-         */
-        long stake;
+public record AddressBookResponse(List<NodeAddress> nodeAddresses) {
+    public AddressBookResponse() {
+        this(new ArrayList<>());
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class Endpoint {
-        @Nullable
-        String address;
+    public record NodeAddress(
+            @Nullable String publicKey,
+            @Nullable String accountId,
+            long nodeId,
+            @Nullable String certHash,
+            List<Endpoint> serviceEndpoints,
+            @Nullable String description,
+            long stake) {}
 
-        int port;
-
-        String domainName;
-    }
+    public record Endpoint(@Nullable String address, int port, String domainName) {}
 
     public void addNodeAddress(NodeAddress nodeAddress) {
         Objects.requireNonNull(nodeAddress, "nodeAddress must not be null");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AddressBookResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/AddressBookResponse.java
@@ -6,11 +6,27 @@ import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
+/**
+ * Represent the addressBook query response.
+ *
+ * @param nodeAddresses the list of node address containing network node information
+ */
 public record AddressBookResponse(List<NodeAddress> nodeAddresses) {
     public AddressBookResponse() {
         this(new ArrayList<>());
     }
 
+    /**
+     * Represent the node address.
+     *
+     * @param publicKey the RSA public key of the node
+     * @param accountId the account to be paid for queries and transactions sent to this node
+     * @param nodeId a non-sequential identifier for the node
+     * @param certHash a hash of the X509 cert used for gRPC traffic to this node
+     * @param serviceEndpoints a node's service IP addresses and ports
+     * @param description a description of the node, with UTF-8 encoding up to 100 bytes
+     * @param stake the amount of tinybars staked to the node
+     */
     public record NodeAddress(
             @Nullable String publicKey,
             @Nullable String accountId,
@@ -20,6 +36,13 @@ public record AddressBookResponse(List<NodeAddress> nodeAddresses) {
             @Nullable String description,
             long stake) {}
 
+    /**
+     * Represent endpoint for the node address.
+     *
+     * @param address the IPv4 address in hex format
+     * @param port the port number for the service endpoint
+     * @param domainName the domain name for the endpoint
+     */
     public record Endpoint(@Nullable String address, int port, String domainName) {}
 
     public void addNodeAddress(NodeAddress nodeAddress) {

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractByteCodeResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractByteCodeResponse.java
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import lombok.Data;
-
-@Data
-public class ContractByteCodeResponse {
-    private final String contractId;
-    private final String bytecode;
-}
+public record ContractByteCodeResponse(String contractId, String bytecode) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractByteCodeResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractByteCodeResponse.java
@@ -1,4 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
+/**
+ * Represent the contractByteCode response.
+ *
+ * @param contractId the ID of the contract
+ * @param bytecode the contract bytecode hex string
+ */
 public record ContractByteCodeResponse(String contractId, String bytecode) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.ContractLogInfo;
-import com.hedera.hashgraph.sdk.Hbar;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -15,7 +13,7 @@ public record ContractCallResponse(
         long gasUsed,
         List<ContractLogInfo> logs,
         long gas,
-        Hbar hbarAmount,
-        @Nullable AccountId senderAccountId,
+        String hbarAmount,
+        @Nullable String senderAccountId,
         long signerNonce,
         String rawResult) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
@@ -7,59 +7,15 @@ import com.hedera.hashgraph.sdk.ContractLogInfo;
 import com.hedera.hashgraph.sdk.Hbar;
 import java.util.List;
 import javax.annotation.Nullable;
-import lombok.Data;
 
-@Data
-public class ContractCallResponse {
-
-    /**
-     * The ID of the contract that was invoked.
-     */
-    public final String contractId;
-
-    /**
-     * The contract's 20-byte EVM address
-     */
-    @Nullable
-    public final ContractId evmAddress;
-
-    /**
-     * message in case there was an error during smart contract execution
-     */
-    @Nullable
-    public final String errorMessage;
-
-    /**
-     * units of gas used to execute contract
-     */
-    public final long gasUsed;
-
-    /**
-     * the log info for events returned by the function
-     */
-    public final List<ContractLogInfo> logs;
-
-    /**
-     * The amount of gas available for the call, aka the gasLimit
-     */
-    public final long gas;
-
-    /**
-     * Number of tinybars sent (the function must be payable if this is nonzero).
-     */
-    public final Hbar hbarAmount;
-
-    /**
-     * The account that is the "sender." If not present it is the accountId from the transactionId.
-     */
-    @Nullable
-    public final AccountId senderAccountId;
-
-    /**
-     * If not null this field specifies what the value of the signer account nonce is post transaction execution.
-     * For transactions that don't update the signer nonce (like HAPI ContractCall and ContractCreate transactions) this field should be null.
-     */
-    public final long signerNonce;
-
-    private final String rawResult;
-}
+public record ContractCallResponse(
+        String contractId,
+        @Nullable ContractId evmAddress,
+        @Nullable String errorMessage,
+        long gasUsed,
+        List<ContractLogInfo> logs,
+        long gas,
+        Hbar hbarAmount,
+        @Nullable AccountId senderAccountId,
+        long signerNonce,
+        String rawResult) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponse.java
@@ -6,6 +6,20 @@ import com.hedera.hashgraph.sdk.ContractLogInfo;
 import java.util.List;
 import javax.annotation.Nullable;
 
+/**
+ * Represent contractCall response.
+ *
+ * @param contractId the ID of the contract that was invoked
+ * @param evmAddress the contract's 20-byte EVM address
+ * @param errorMessage the message in case there was an error during smart contract execution
+ * @param gasUsed the units of gas used to execute contract
+ * @param logs the log info for events returned by the function
+ * @param gas the amount of gas available for the call, aka the gasLimit
+ * @param hbarAmount the Number of tinybars sent (the function must be payable if this is nonzero)
+ * @param senderAccountId the account that is the "sender" If not present it is the accountId from the transactionId
+ * @param signerNonce if not null this field specifies what the value of the signer account nonce is post transaction execution
+ * @param rawResult the raw return data on the function call
+ */
 public record ContractCallResponse(
         String contractId,
         @Nullable ContractId evmAddress,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractResponse.java
@@ -2,46 +2,31 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class ContractResponse {
-    private String contractId;
-    private Status status;
+public record ContractResponse(String contractId, Status status) {
 
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class ContractInfoQueryResponse {
-        private String contractId;
-        private String accountId;
-        private String contractAccountId;
-        private String adminKey;
-        private String expirationTime;
-        private String autoRenewPeriod;
-        private String autoRenewAccountId;
-        private String storage;
-        private String contractMemo;
-        private String balance;
-        private Boolean isDeleted;
-        private String maxAutomaticTokenAssociations;
-        private String ledgerId;
-        private StakingInfoResponse stakingInfo;
+    public record ContractInfoQueryResponse(
+            String contractId,
+            String accountId,
+            String contractAccountId,
+            String adminKey,
+            String expirationTime,
+            String autoRenewPeriod,
+            String autoRenewAccountId,
+            String storage,
+            String contractMemo,
+            String balance,
+            Boolean isDeleted,
+            String maxAutomaticTokenAssociations,
+            String ledgerId,
+            StakingInfoResponse stakingInfo) {
 
-        @Data
-        @AllArgsConstructor
-        @NoArgsConstructor
-        public static class StakingInfoResponse {
-            private Boolean declineStakingReward;
-            private String stakePeriodStart;
-            private String pendingReward;
-            private String stakedToMe;
-            private String stakedAccountId;
-            private String stakedNodeId;
-        }
+        public record StakingInfoResponse(
+                Boolean declineStakingReward,
+                String stakePeriodStart,
+                String pendingReward,
+                String stakedToMe,
+                String stakedAccountId,
+                String stakedNodeId) {}
     }
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractResponse.java
@@ -3,8 +3,32 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent the contract response.
+ *
+ * @param contractId the ID of the contract
+ * @param status the status of the submitted transaction
+ */
 public record ContractResponse(String contractId, Status status) {
 
+    /**
+     * Represent the contractInfo query response.
+     *
+     * @param contractId the ID of the contract
+     * @param accountId the account ID associated with the contract
+     * @param contractAccountId the contract account ID
+     * @param adminKey the admin key controlling the contract
+     * @param expirationTime the expiration time of the contract
+     * @param autoRenewPeriod the auto_renew period in seconds
+     * @param autoRenewAccountId the account ID for auto_renewal
+     * @param storage the storage used by the contract
+     * @param contractMemo the memo associated with the contract
+     * @param balance the contract balance in tinybars
+     * @param isDeleted state whether the contract is deleted
+     * @param maxAutomaticTokenAssociations the maximum number of automatic token associations
+     * @param ledgerId the ledger ID
+     * @param stakingInfo the staking information
+     */
     public record ContractInfoQueryResponse(
             String contractId,
             String accountId,
@@ -21,6 +45,16 @@ public record ContractResponse(String contractId, Status status) {
             String ledgerId,
             StakingInfoResponse stakingInfo) {
 
+        /**
+         * Represent the stakingInfo.
+         *
+         * @param declineStakingReward state whether staking rewards are declined
+         * @param stakePeriodStart the stake period start timestamp
+         * @param pendingReward the pending reward in tinybars
+         * @param stakedToMe the amount staked to this contract in tinybars
+         * @param stakedAccountId the account ID staked to
+         * @param stakedNodeId the node ID staked to
+         */
         public record StakingInfoResponse(
                 Boolean declineStakingReward,
                 String stakePeriodStart,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/EthereumTransactionResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/EthereumTransactionResponse.java
@@ -1,4 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
+/**
+ * Represent ethereumTransaction response.
+ *
+ * @param status the status of the submitted transaction
+ * @param contractId the ID of the created contract
+ */
 public record EthereumTransactionResponse(String status, String contractId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/EthereumTransactionResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/EthereumTransactionResponse.java
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import lombok.Data;
-
-@Data
-public class EthereumTransactionResponse {
-    private final String status;
-    private final String contractId;
-}
+public record EthereumTransactionResponse(String status, String contractId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileContentsResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileContentsResponse.java
@@ -1,4 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
+/**
+ * Represent fileContent query response.
+ *
+ * @param contents the contents of the file
+ */
 public record FileContentsResponse(String contents) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileContentsResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileContentsResponse.java
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import lombok.Data;
-
-@Data
-public class FileContentsResponse {
-    private final String contents;
-}
+public record FileContentsResponse(String contents) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileInfoResponse.java
@@ -3,6 +3,17 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import java.util.List;
 
+/**
+ * Represent the fileInfo response.
+ *
+ * @param fileId the file ID
+ * @param size the current file size in bytes
+ * @param expirationTime the time at which this file is set to expire
+ * @param isDeleted if true, then this file has been deleted
+ * @param memo the memo associated with the file
+ * @param ledgerId the ID of the ledger from which the response was returned
+ * @param keys the keys required to modify the file
+ */
 public record FileInfoResponse(
         String fileId,
         String size,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileInfoResponse.java
@@ -2,17 +2,12 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-@Data
-@AllArgsConstructor
-public class FileInfoResponse {
-    private final String fileId;
-    private final String size;
-    private final String expirationTime;
-    private final Boolean isDeleted;
-    private final String memo;
-    private final String ledgerId;
-    private final List<String> keys;
-}
+public record FileInfoResponse(
+        String fileId,
+        String size,
+        String expirationTime,
+        Boolean isDeleted,
+        String memo,
+        String ledgerId,
+        List<String> keys) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileResponse.java
@@ -3,4 +3,10 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent the response for file related transactions.
+ *
+ * @param fileId the ID of the file
+ * @param status the status of the submitted transaction
+ */
 public record FileResponse(String fileId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/FileResponse.java
@@ -2,10 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.Data;
 
-@Data
-public class FileResponse {
-    private final String fileId;
-    private final Status status;
-}
+public record FileResponse(String fileId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponse.java
@@ -3,4 +3,10 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import java.util.List;
 
+/**
+ * Represent generated key response.
+ *
+ * @param key the generated key
+ * @param privateKeys the list of generated private keys
+ */
 public record GenerateKeyResponse(String key, List<String> privateKeys) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponse.java
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import java.util.ArrayList;
 import java.util.List;
-import lombok.Data;
 
-@Data
-public class GenerateKeyResponse {
-    private String key;
-    private List<String> privateKeys = new ArrayList<>();
-}
+public record GenerateKeyResponse(String key, List<String> privateKeys) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GetAccountInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GetAccountInfoResponse.java
@@ -5,7 +5,32 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Response for getAccountInfo query
+ * Represent response for getAccountInfo query.
+ *
+ * @param accountId the account ID
+ * @param contractAccountId the contract account ID comprising both the contract instance and the cryptocurrency account
+ * @param isDeleted if true, then this account has been deleted
+ * @param proxyAccountId the account ID of the account to which this account is proxy staked
+ * @param proxyReceived the total number of tinybars proxy staked to this account
+ * @param key the key for the account, which must sign
+ * @param balance the current balance of the account in tinybars
+ * @param sendRecordThreshold the threshold amount (in tinybars) for which an account record is created for any send/withdraw transaction
+ * @param receiveRecordThreshold the threshold amount (in tinybars) for which an account record is created for any receive/deposit transaction
+ * @param isReceiverSignatureRequired if true, no transaction can transfer to this account unless signed by this account's key
+ * @param expirationTime the time at which this account is set to expire
+ * @param autoRenewPeriod the duration for expiration time will extend every this many seconds
+ * @param liveHashes all the livehashes attached to the account
+ * @param tokenRelationships all tokens related to this account
+ * @param accountMemo the memo associated with the account
+ * @param ownedNfts the number of NFTs owned by this account
+ * @param maxAutomaticTokenAssociations the maximum number of tokens that an account can be implicitly associated with
+ * @param aliasKey the public key to be used as the account's alias
+ * @param ledgerId the ID of the ledger from which the response was returned
+ * @param hbarAllowances list of hbar allowances approved by this account
+ * @param tokenAllowances list of fungible token allowances approved by this account
+ * @param nftAllowances list of non-fungible token allowances approved by this account
+ * @param ethereumNonce the ethereum transaction nonce associated with this account
+ * @param stakingInfo the staking metadata for this account
  */
 public record GetAccountInfoResponse(
         String accountId,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GetAccountInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/GetAccountInfoResponse.java
@@ -3,122 +3,82 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * Response for getAccountInfo query
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class GetAccountInfoResponse {
-    private String accountId;
-    private String contractAccountId;
-    private boolean isDeleted;
-    private String proxyAccountId;
-    private String proxyReceived;
-    private String key;
-    private String balance;
-    private String sendRecordThreshold;
-    private String receiveRecordThreshold;
-    private boolean isReceiverSignatureRequired;
-    private String expirationTime;
-    private String autoRenewPeriod;
-    private List<LiveHashResponse> liveHashes;
-    private Map<String, TokenRelationshipInfo> tokenRelationships;
-    private String accountMemo;
-    private String ownedNfts;
-    private String maxAutomaticTokenAssociations;
-    private String aliasKey;
-    private String ledgerId;
-    private List<HbarAllowanceResponse> hbarAllowances;
-    private List<TokenAllowanceResponse> tokenAllowances;
-    private List<TokenNftAllowanceResponse> nftAllowances;
-    private String ethereumNonce;
-    private StakingInfoResponse stakingInfo;
+public record GetAccountInfoResponse(
+        String accountId,
+        String contractAccountId,
+        boolean isDeleted,
+        String proxyAccountId,
+        String proxyReceived,
+        String key,
+        String balance,
+        String sendRecordThreshold,
+        String receiveRecordThreshold,
+        boolean isReceiverSignatureRequired,
+        String expirationTime,
+        String autoRenewPeriod,
+        List<LiveHashResponse> liveHashes,
+        Map<String, TokenRelationshipInfo> tokenRelationships,
+        String accountMemo,
+        String ownedNfts,
+        String maxAutomaticTokenAssociations,
+        String aliasKey,
+        String ledgerId,
+        List<HbarAllowanceResponse> hbarAllowances,
+        List<TokenAllowanceResponse> tokenAllowances,
+        List<TokenNftAllowanceResponse> nftAllowances,
+        String ethereumNonce,
+        StakingInfoResponse stakingInfo) {
 
     /**
      * LiveHashResponse for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LiveHashResponse {
-        private String accountId;
-        private String hash;
-        private List<String> keys;
-        private String duration;
-    }
+    public record LiveHashResponse(String accountId, String hash, List<String> keys, String duration) {}
 
     /**
      * TokenRelationshipInfo for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class TokenRelationshipInfo {
-        private String tokenId;
-        private String symbol;
-        private String balance;
-        private Boolean isKycGranted;
-        private Boolean isFrozen;
-        private Boolean automaticAssociation;
-    }
+    public record TokenRelationshipInfo(
+            String tokenId,
+            String symbol,
+            String balance,
+            Boolean isKycGranted,
+            Boolean isFrozen,
+            Boolean automaticAssociation) {}
 
     /**
      * HbarAllowanceResponse for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class HbarAllowanceResponse {
-        private String ownerAccountId;
-        private String spenderAccountId;
-        private String amount;
-    }
+    public record HbarAllowanceResponse(String ownerAccountId, String spenderAccountId, String amount) {}
 
     /**
      * TokenAllowanceResponse for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class TokenAllowanceResponse {
-        private String tokenId;
-        private String ownerAccountId;
-        private String spenderAccountId;
-        private String amount;
-    }
+    public record TokenAllowanceResponse(
+            String tokenId, String ownerAccountId, String spenderAccountId, String amount) {}
 
     /**
      * TokenNftAllowanceResponse for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class TokenNftAllowanceResponse {
-        private String tokenId;
-        private String ownerAccountId;
-        private String spenderAccountId;
-        private List<String> serialNumbers;
-        private Boolean allSerials;
-        private String delegatingSpender;
-    }
+    public record TokenNftAllowanceResponse(
+            String tokenId,
+            String ownerAccountId,
+            String spenderAccountId,
+            List<String> serialNumbers,
+            Boolean allSerials,
+            String delegatingSpender) {}
 
     /**
      * StakingInfoResponse for account info
      */
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class StakingInfoResponse {
-        private boolean declineStakingReward;
-        private String stakePeriodStart;
-        private String pendingReward;
-        private String stakedToMe;
-        private String stakedAccountId;
-        private String stakedNodeId;
-    }
+    public record StakingInfoResponse(
+            boolean declineStakingReward,
+            String stakePeriodStart,
+            String pendingReward,
+            String stakedToMe,
+            String stakedAccountId,
+            String stakedNodeId) {}
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/NodeResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/NodeResponse.java
@@ -3,4 +3,10 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent the response for all the node related transaction.
+ *
+ * @param nodeId the ID of the node
+ * @param status the status of the submitted transaction
+ */
 public record NodeResponse(String nodeId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/NodeResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/NodeResponse.java
@@ -2,10 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.Data;
 
-@Data
-public class NodeResponse {
-    private final String nodeId;
-    private final Status status;
-}
+public record NodeResponse(String nodeId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponse.java
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
+/**
+ * Represent the setup response.
+ *
+ * @param message the message to return
+ * @param status the status of the submitted transaction
+ */
 public record SetupResponse(String message, String status) {
     public SetupResponse(String message) {
         this(message == null || message.isEmpty() ? "" : message, "SUCCESS");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponse.java
@@ -1,17 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
-import lombok.Data;
-
-@Data
-public class SetupResponse {
-    private String message = "";
-    private String status = "";
-
+public record SetupResponse(String message, String status) {
     public SetupResponse(String message) {
-        if (message != null && !message.isEmpty()) {
-            this.message = message;
-        }
-        this.status = "SUCCESS";
+        this(message == null || message.isEmpty() ? "" : message, "SUCCESS");
     }
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicInfoResponse.java
@@ -4,55 +4,27 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import java.util.List;
-import lombok.Data;
 
-@Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class TopicInfoResponse {
-    private final String topicId;
-    private final String topicMemo;
-    private final String sequenceNumber;
-    private final String runningHash;
+public record TopicInfoResponse(
+        String topicId,
+        String topicMemo,
+        String sequenceNumber,
+        String runningHash,
+        @Nullable String adminKey,
+        @Nullable String submitKey,
+        @Nullable String autoRenewAccountId,
+        String autoRenewPeriod,
+        String expirationTime,
+        @Nullable String feeScheduleKey,
+        @Nullable List<String> feeExemptKeys,
+        @Nullable List<CustomFeeResponse> customFees,
+        String ledgerId) {
 
-    @Nullable
-    private final String adminKey;
-
-    @Nullable
-    private final String submitKey;
-
-    @Nullable
-    private final String autoRenewAccountId;
-
-    private final String autoRenewPeriod;
-    private final String expirationTime;
-
-    @Nullable
-    private final String feeScheduleKey;
-
-    @Nullable
-    private final List<String> feeExemptKeys;
-
-    @Nullable
-    private final List<CustomFeeResponse> customFees;
-
-    private final String ledgerId;
-
-    @Data
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class CustomFeeResponse {
-        @Nullable
-        private final String feeCollectorAccountId;
+    public record CustomFeeResponse(
+            @Nullable String feeCollectorAccountId, Boolean allCollectorsAreExempt, FixedFeeResponse fixedFee) {}
 
-        private final Boolean allCollectorsAreExempt;
-        private final FixedFeeResponse fixedFee;
-    }
-
-    @Data
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class FixedFeeResponse {
-        private final String amount;
-
-        @Nullable
-        private final String denominatingTokenId;
-    }
+    public record FixedFeeResponse(String amount, @Nullable String denominatingTokenId) {}
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicInfoResponse.java
@@ -5,6 +5,23 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
+/**
+ * Represent the topicInfo response.
+ *
+ * @param topicId the ID of the topic
+ * @param topicMemo the publicly visible memo about the topic
+ * @param sequenceNumber the sequence number of the last message submitted to the topic
+ * @param runningHash the running hash
+ * @param adminKey the admin key of the topic
+ * @param submitKey the submit key of the topic
+ * @param autoRenewAccountId the account ID that pays for auto-renewal
+ * @param autoRenewPeriod the auto-renewal period in seconds
+ * @param expirationTime the expiration time of the topic
+ * @param feeScheduleKey the fee schedule key of the topic
+ * @param feeExemptKeys the list of fee exempt keys
+ * @param customFees the custom fees associated with the topic
+ * @param ledgerId the ledger ID of the network
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record TopicInfoResponse(
         String topicId,
@@ -21,10 +38,23 @@ public record TopicInfoResponse(
         @Nullable List<CustomFeeResponse> customFees,
         String ledgerId) {
 
+    /**
+     * Represent customFee response.
+     *
+     * @param feeCollectorAccountId the ID of the account to which all fees will be sent when assessed
+     * @param allCollectorsAreExempt whether all fee collector accounts are exempt from being * charged fees when transferring the token
+     * @param fixedFee the parameters of the Fixed Fee to assess
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record CustomFeeResponse(
             @Nullable String feeCollectorAccountId, Boolean allCollectorsAreExempt, FixedFeeResponse fixedFee) {}
 
+    /**
+     * Represent fixedFee response.
+     *
+     * @param amount the amount to be assessed as a fee
+     * @param denominatingTokenId the ID of the token to use to assess the fee
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record FixedFeeResponse(String amount, @Nullable String denominatingTokenId) {}
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicResponse.java
@@ -2,10 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class TopicResponse {
-    private String topicId;
-    private Status status;
-}
+public record TopicResponse(String topicId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TopicResponse.java
@@ -3,4 +3,10 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent response for topic related transaction.
+ *
+ * @param topicId the ID of the topic
+ * @param status the status of the submitted transaction
+ */
 public record TopicResponse(String topicId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TransactionReceiptResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TransactionReceiptResponse.java
@@ -3,59 +3,27 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
-import lombok.Data;
 import org.jspecify.annotations.Nullable;
 
-@Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class TransactionReceiptResponse {
-    private final String status;
+public record TransactionReceiptResponse(
+        String status,
+        @Nullable String accountId,
+        @Nullable String fileId,
+        @Nullable String contractId,
+        @Nullable String topicId,
+        @Nullable String tokenId,
+        @Nullable String scheduleId,
+        @Nullable ExchangeRate exchangeRate,
+        @Nullable String topicSequenceNumber,
+        @Nullable String topicRunningHash,
+        @Nullable String totalSupply,
+        @Nullable String scheduledTransactionId,
+        List<Long> serials,
+        List<TransactionReceiptResponse> duplicates,
+        List<TransactionReceiptResponse> children,
+        @Nullable String nodeId) {
 
-    @Nullable
-    private final String accountId;
-
-    @Nullable
-    private final String fileId;
-
-    @Nullable
-    private final String contractId;
-
-    @Nullable
-    private final String topicId;
-
-    @Nullable
-    private final String tokenId;
-
-    @Nullable
-    private final String scheduleId;
-
-    @Nullable
-    private final ExchangeRate exchangeRate;
-
-    @Nullable
-    private final String topicSequenceNumber;
-
-    @Nullable
-    private final String topicRunningHash;
-
-    @Nullable
-    private final String totalSupply;
-
-    @Nullable
-    private final String scheduledTransactionId;
-
-    private final List<Long> serials;
-    private final List<TransactionReceiptResponse> duplicates;
-    private final List<TransactionReceiptResponse> children;
-
-    @Nullable
-    private final String nodeId;
-
-    @Data
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class ExchangeRate {
-        private final Long hbars;
-        private final Long cents;
-        private final String expirationTime;
-    }
+    public record ExchangeRate(Long hbars, Long cents, String expirationTime) {}
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TransactionReceiptResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/TransactionReceiptResponse.java
@@ -5,6 +5,26 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Represent transactionReceipt response.
+ *
+ * @param status the status of the transaction
+ * @param accountId the account ID of a newly created account
+ * @param fileId the file ID of a newly created file
+ * @param contractId the contract ID of a newly created contract
+ * @param topicId the topic ID of a newly created topic
+ * @param tokenId the token ID of a newly created token
+ * @param scheduleId the schedule ID of a newly created schedule
+ * @param exchangeRate the exchange rate at the time of the transaction
+ * @param topicSequenceNumber the sequence number for a consensus service topic message
+ * @param topicRunningHash the running hash for a consensus service topic
+ * @param totalSupply the total supply of a token after a mint/burn operation
+ * @param scheduledTransactionId the transaction ID of the scheduled transaction
+ * @param serials the serial numbers of newly created NFTs
+ * @param duplicates list of duplicate transaction receipts
+ * @param children list of child transaction receipts
+ * @param nodeId the node ID affected by a node related transaction
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record TransactionReceiptResponse(
         String status,
@@ -24,6 +44,13 @@ public record TransactionReceiptResponse(
         List<TransactionReceiptResponse> children,
         @Nullable String nodeId) {
 
+    /**
+     * Represent exchangeRate response.
+     *
+     * @param hbars the number of hbars in the exchange rate
+     * @param cents the number of cents (USD) in the exchange rate
+     * @param expirationTime the expiration time of the exchange rate
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record ExchangeRate(Long hbars, Long cents, String expirationTime) {}
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleInfoResponse.java
@@ -5,6 +5,22 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import java.util.List;
 
+/**
+ * Represent the scheduleInfo query response
+ *
+ * @param scheduleId the ID of the schedule transaction
+ * @param creatorAccountId the account that created the schedule transaction
+ * @param payerAccountId the account that will pay for the execution of the scheduled transaction
+ * @param adminKey the key that can delete the schedule transaction
+ * @param signers the public keys that have signed the scheduled transaction
+ * @param scheduleMemo publicly visible information about the schedule entity
+ * @param expirationTime the date and time at which the schedule transaction will expire
+ * @param executed the consensus time the schedule transaction was executed
+ * @param deleted the consensus time the schedule transaction was deleted
+ * @param scheduledTransactionId the transaction ID of the transaction being scheduled
+ * @param waitForExpiry whether the scheduled transaction should wait for expiry before executing
+ * @param cost the cost of the query in tinybars
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ScheduleInfoResponse(
         String scheduleId,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleInfoResponse.java
@@ -4,40 +4,21 @@ package com.hedera.hashgraph.tck.methods.sdk.response.schedule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-@Data
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ScheduleInfoResponse {
-    private String scheduleId;
-    private String creatorAccountId;
-    private String payerAccountId;
-
-    @Nullable
-    private String adminKey;
-
-    private List<String> signers;
-    private String scheduleMemo;
-
-    @Nullable
-    private String expirationTime;
-
-    @Nullable
-    private String executed;
-
-    @Nullable
-    private String deleted;
-
-    @Nullable
-    private String scheduledTransactionId;
-
-    private Boolean waitForExpiry;
-
-    @Nullable
-    private String cost;
-
+public record ScheduleInfoResponse(
+        String scheduleId,
+        String creatorAccountId,
+        String payerAccountId,
+        @Nullable String adminKey,
+        List<String> signers,
+        String scheduleMemo,
+        @Nullable String expirationTime,
+        @Nullable String executed,
+        @Nullable String deleted,
+        @Nullable String scheduledTransactionId,
+        Boolean waitForExpiry,
+        @Nullable String cost) {
     public static ScheduleInfoResponse forCostOnly(String cost) {
         return new ScheduleInfoResponse(null, null, null, null, null, null, null, null, null, null, null, cost);
     }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleResponse.java
@@ -3,4 +3,11 @@ package com.hedera.hashgraph.tck.methods.sdk.response.schedule;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent response for the schedule related transaction.
+ *
+ * @param scheduleId the ID of the created schedule
+ * @param transactionId the ID of the scheduled transaction
+ * @param status the status of the submitted transaction
+ */
 public record ScheduleResponse(String scheduleId, String transactionId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/schedule/ScheduleResponse.java
@@ -2,11 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response.schedule;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.Data;
 
-@Data
-public class ScheduleResponse {
-    private final String scheduleId;
-    private final String transactionId;
-    private final Status status;
-}
+public record ScheduleResponse(String scheduleId, String transactionId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/NftInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/NftInfoResponse.java
@@ -3,6 +3,16 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import javax.annotation.Nullable;
 
+/**
+ * Represent nftInfo query responsee.
+ *
+ * @param nftId the ID of the NFT
+ * @param accountId the current owner of the NFT
+ * @param creationTime the effective consensus timestamp at which the NFT was minted
+ * @param metadata the unique metadata of the NFT
+ * @param ledgerId the ledger ID the response was returned from
+ * @param spenderId if an allowance is granted for the NFT, its corresponding spender account
+ */
 public record NftInfoResponse(
         String nftId,
         String accountId,

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/NftInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/NftInfoResponse.java
@@ -2,39 +2,11 @@
 package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import javax.annotation.Nullable;
-import lombok.Data;
 
-@Data
-public class NftInfoResponse {
-
-    /**
-     * The ID of the NFT
-     */
-    public final String nftId;
-
-    /**
-     * The current owner of the NFT
-     */
-    public final String accountId;
-
-    /**
-     * The effective consensus timestamp at which the NFT was minted
-     */
-    public final String creationTime;
-
-    /**
-     * Represents the unique metadata of the NFT
-     */
-    public final String metadata;
-
-    /**
-     * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
-     */
-    public final String ledgerId;
-
-    /**
-     * If an allowance is granted for the NFT, its corresponding spender account
-     */
-    @Nullable
-    public final String spenderId;
-}
+public record NftInfoResponse(
+        String nftId,
+        String accountId,
+        String creationTime,
+        String metadata,
+        String ledgerId,
+        @Nullable String spenderId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenBurnResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenBurnResponse.java
@@ -3,4 +3,11 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent a tokenBurn transaction response.
+ *
+ * @param tokenId the ID of the token to burn
+ * @param status the status of the submitted transaction
+ * @param newTotalSupply the new total amount of tokens
+ */
 public record TokenBurnResponse(String tokenId, Status status, String newTotalSupply) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenBurnResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenBurnResponse.java
@@ -3,12 +3,4 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import com.hedera.hashgraph.sdk.Status;
 
-public class TokenBurnResponse extends TokenResponse {
-
-    private final String newTotalSupply;
-
-    public TokenBurnResponse(String tokenId, Status status, String newTotalSupply) {
-        super(tokenId, status);
-        this.newTotalSupply = newTotalSupply;
-    }
-}
+public record TokenBurnResponse(String tokenId, Status status, String newTotalSupply) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenInfoResponse.java
@@ -7,57 +7,64 @@ import com.hedera.hashgraph.sdk.TokenType;
 import java.util.List;
 import javax.annotation.Nullable;
 
+/**
+ * Represent the tokenInfo query response.
+ *
+ * @param tokenId the ID of the token for which information is requested
+ * @param name the name of token
+ * @param symbol the symbol of token
+ * @param decimals the amount of decimal places that this token supports
+ * @param totalSupply total Supply of token
+ * @param treasuryAccountId the ID of the account which is set as treasury
+ * @param adminKey the key which can perform update/delete operations on the token
+ * @param kycKey the key which can grant or revoke KYC of an account for the token's transactions
+ * @param freezeKey the key which can freeze or unfreeze an account for token transactions
+ * @param wipeKey the key which can wipe token balance of an account
+ * @param supplyKey the key which can change the supply of a token
+ * @param feeScheduleKey the key which can change the custom fees of the token
+ * @param defaultFreezeStatus the default Freeze status (not applicable, frozen or unfrozen) of Hedera accounts relative to this token
+ * @param defaultKycStatus the default KYC status (KycNotApplicable or Revoked) of Hedera accounts relative to this token
+ * @param isDeleted specifies whether the token was deleted or not
+ * @param autoRenewAccountId an account which will be automatically charged to renew the token's expiration, at autoRenewPeriod interval
+ * @param autoRenewPeriod the interval at which the auto_renew account will be charged to extend the token's expiry
+ * @param expirationTime the epoch second at which the token will expire
+ * @param tokenMemo the memo associated with the token
+ * @param customFees the custom fees to be assessed during a CryptoTransfer that transfers units of this token
+ * @param tokenType the token type
+ * @param supplyType the token supply type
+ * @param maxSupply the maximum number of fungible tokens that can be in circulation
+ * @param pauseKey the Key which can pause and unpause the token
+ * @param pauseStatus specifies whether the token is paused or not, null if pauseKey is not set.
+ * @param metadata the metadata for the nft
+ * @param metadataKey the key which can change the metadata of a token
+ * @param ledgerId the ledger ID
+ */
 public record TokenInfoResponse(
         String tokenId,
         String name,
-
         String symbol,
-
         int decimals,
-
         String totalSupply,
-
         String treasuryAccountId,
-
         @Nullable String adminKey,
-
         @Nullable String kycKey,
         @Nullable String freezeKey,
-
         @Nullable String wipeKey,
-
         @Nullable String supplyKey,
-
         @Nullable String feeScheduleKey,
-
         @Nullable Boolean defaultFreezeStatus,
-
         @Nullable Boolean defaultKycStatus,
-
         boolean isDeleted,
-
         @Nullable String autoRenewAccountId,
-
         @Nullable String autoRenewPeriod,
-
         @Nullable String expirationTime,
-
         String tokenMemo,
-
         List<CustomFee> customFees,
-
         TokenType tokenType,
-
         TokenSupplyType supplyType,
-
         String maxSupply,
-
         @Nullable String pauseKey,
-
         @Nullable Boolean pauseStatus,
-
         String metadata,
-
         @Nullable String metadataKey,
-
         String ledgerId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenInfoResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenInfoResponse.java
@@ -6,166 +6,58 @@ import com.hedera.hashgraph.sdk.TokenSupplyType;
 import com.hedera.hashgraph.sdk.TokenType;
 import java.util.List;
 import javax.annotation.Nullable;
-import lombok.Data;
 
-@Data
-public class TokenInfoResponse {
+public record TokenInfoResponse(
+        String tokenId,
+        String name,
 
-    /**
-     * The ID of the token for which information is requested.
-     */
-    public final String tokenId;
+        String symbol,
 
-    /**
-     * Name of token.
-     */
-    public final String name;
+        int decimals,
 
-    /**
-     * Symbol of token.
-     */
-    public final String symbol;
+        String totalSupply,
 
-    /**
-     * The amount of decimal places that this token supports.
-     */
-    public final int decimals;
+        String treasuryAccountId,
 
-    /**
-     * Total Supply of token.
-     */
-    public final String totalSupply;
+        @Nullable String adminKey,
 
-    /**
-     * The ID of the account which is set as Treasury
-     */
-    public final String treasuryAccountId;
+        @Nullable String kycKey,
+        @Nullable String freezeKey,
 
-    /**
-     * The key which can perform update/delete operations on the token. If empty, the token can be perceived as immutable (not being able to be updated/deleted)
-     */
-    @Nullable
-    public final String adminKey;
+        @Nullable String wipeKey,
 
-    /**
-     * The key which can grant or revoke KYC of an account for the token's transactions. If empty, KYC is not required, and KYC grant or revoke operations are not possible.
-     */
-    @Nullable
-    public final String kycKey;
+        @Nullable String supplyKey,
 
-    /**
-     * The key which can freeze or unfreeze an account for token transactions. If empty, freezing is not possible
-     */
-    @Nullable
-    public final String freezeKey;
+        @Nullable String feeScheduleKey,
 
-    /**
-     * The key which can wipe token balance of an account. If empty, wipe is not possible
-     */
-    @Nullable
-    public final String wipeKey;
+        @Nullable Boolean defaultFreezeStatus,
 
-    /**
-     * The key which can change the supply of a token. The key is used to sign Token Mint/Burn operations
-     */
-    @Nullable
-    public final String supplyKey;
+        @Nullable Boolean defaultKycStatus,
 
-    /**
-     * The key which can change the custom fees of the token; if not set, the fees are immutable
-     */
-    @Nullable
-    public final String feeScheduleKey;
+        boolean isDeleted,
 
-    /**
-     * The default Freeze status (not applicable, frozen or unfrozen) of Hedera accounts relative to this token. FreezeNotApplicable is returned if Token Freeze Key is empty. Frozen is returned if Token Freeze Key is set and defaultFreeze is set to true. Unfrozen is returned if Token Freeze Key is set and defaultFreeze is set to false
-     */
-    @Nullable
-    public final Boolean defaultFreezeStatus;
+        @Nullable String autoRenewAccountId,
 
-    /**
-     * The default KYC status (KycNotApplicable or Revoked) of Hedera accounts relative to this token. KycNotApplicable is returned if KYC key is not set, otherwise Revoked
-     */
-    @Nullable
-    public final Boolean defaultKycStatus;
+        @Nullable String autoRenewPeriod,
 
-    /**
-     * Specifies whether the token was deleted or not
-     */
-    public final boolean isDeleted;
+        @Nullable String expirationTime,
 
-    /**
-     * An account which will be automatically charged to renew the token's expiration, at autoRenewPeriod interval
-     */
-    @Nullable
-    public final String autoRenewAccountId;
+        String tokenMemo,
 
-    /**
-     * The interval at which the auto-renew account will be charged to extend the token's expiry
-     */
-    @Nullable
-    public final String autoRenewPeriod;
+        List<CustomFee> customFees,
 
-    /**
-     * The epoch second at which the token will expire
-     */
-    @Nullable
-    public final String expirationTime;
+        TokenType tokenType,
 
-    /**
-     * The memo associated with the token
-     */
-    public final String tokenMemo;
+        TokenSupplyType supplyType,
 
-    /**
-     * The custom fees to be assessed during a CryptoTransfer that transfers units of this token
-     */
-    public final List<CustomFee> customFees;
+        String maxSupply,
 
-    /**
-     * The token type
-     */
-    public final TokenType tokenType;
+        @Nullable String pauseKey,
 
-    /**
-     * The token supply type
-     */
-    public final TokenSupplyType supplyType;
+        @Nullable Boolean pauseStatus,
 
-    /**
-     * For tokens of type FUNGIBLE_COMMON - The Maximum number of fungible tokens that can be in
-     * circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial
-     * numbers) that can be in circulation
-     */
-    public final String maxSupply;
+        String metadata,
 
-    /**
-     * The Key which can pause and unpause the Token.
-     */
-    @Nullable
-    public final String pauseKey;
+        @Nullable String metadataKey,
 
-    /**
-     * Specifies whether the token is paused or not. Null if pauseKey is not set.
-     */
-    @Nullable
-    public final Boolean pauseStatus;
-
-    /**
-     * The key which can change the metadata of a token
-     * (token definition and individual NFTs).
-     */
-    public final String metadata;
-
-    /**
-     * The key which can change the metadata of a token
-     * (token definition and individual NFTs).
-     */
-    @Nullable
-    public final String metadataKey;
-
-    /**
-     * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
-     */
-    public final String ledgerId;
-}
+        String ledgerId) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenMintResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenMintResponse.java
@@ -4,13 +4,4 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 import com.hedera.hashgraph.sdk.Status;
 import java.util.List;
 
-public class TokenMintResponse extends TokenResponse {
-    private final String newTotalSupply;
-    private final List<String> serialNumbers;
-
-    public TokenMintResponse(String tokenId, Status status, String newTotalSupply, List<String> serialNumbers) {
-        super(tokenId, status);
-        this.newTotalSupply = newTotalSupply;
-        this.serialNumbers = serialNumbers;
-    }
-}
+public record TokenMintResponse(String tokenId, Status status, String newTotalSupply, List<String> serialNumbers) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenMintResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenMintResponse.java
@@ -4,4 +4,12 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 import com.hedera.hashgraph.sdk.Status;
 import java.util.List;
 
+/**
+ * Represent tokenMint transaction response.
+ *
+ * @param tokenId the ID of the token to burn
+ * @param status the status of the submitted transaction
+ * @param newTotalSupply the new total amount of tokens
+ * @param serialNumbers list of serial numbers for the NFTs
+ */
 public record TokenMintResponse(String tokenId, Status status, String newTotalSupply, List<String> serialNumbers) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenResponse.java
@@ -2,10 +2,5 @@
 package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import com.hedera.hashgraph.sdk.Status;
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class TokenResponse {
-    private String tokenId;
-    private Status status;
-}
+public record TokenResponse(String tokenId, Status status) {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenResponse.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/response/token/TokenResponse.java
@@ -3,4 +3,10 @@ package com.hedera.hashgraph.tck.methods.sdk.response.token;
 
 import com.hedera.hashgraph.sdk.Status;
 
+/**
+ * Represent the response for the token related transaction.
+ *
+ * @param tokenId the ID of the token
+ * @param status the status of the submitted transaction
+ */
 public record TokenResponse(String tokenId, Status status) {}

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/KeyServiceTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/KeyServiceTest.java
@@ -89,8 +89,8 @@ class KeyServiceTest {
 
         GenerateKeyResponse response = keyService.generateKey(params);
 
-        assertNotNull(response.getKey());
-        assertTrue(response.getKey().contains("302e020100300506032b657004220420"));
+        assertNotNull(response.key());
+        assertTrue(response.key().contains("302e020100300506032b657004220420"));
     }
 
     @Test
@@ -100,8 +100,8 @@ class KeyServiceTest {
 
         GenerateKeyResponse response = keyService.generateKey(params);
 
-        assertNotNull(response.getKey());
-        assertTrue(response.getKey().contains("302a300506032b6570032100"));
+        assertNotNull(response.key());
+        assertTrue(response.key().contains("302a300506032b6570032100"));
     }
 
     @Test
@@ -115,8 +115,8 @@ class KeyServiceTest {
 
         GenerateKeyResponse response = keyService.generateKey(params);
 
-        assertNotNull(response.getKey());
-        assertFalse(response.getPrivateKeys().isEmpty());
+        assertNotNull(response.key());
+        assertFalse(response.privateKeys().isEmpty());
     }
 
     @Test
@@ -130,8 +130,8 @@ class KeyServiceTest {
 
         GenerateKeyResponse response = keyService.generateKey(params);
 
-        assertNotNull(response.getKey());
-        assertFalse(response.getPrivateKeys().isEmpty());
+        assertNotNull(response.key());
+        assertFalse(response.privateKeys().isEmpty());
     }
 
     @Test
@@ -145,6 +145,6 @@ class KeyServiceTest {
 
         GenerateKeyResponse response = keyService.generateKey(params);
 
-        assertNotNull(response.getKey());
+        assertNotNull(response.key());
     }
 }

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/SdkServiceTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/SdkServiceTest.java
@@ -34,11 +34,11 @@ class SdkServiceTest {
         SetupResponse response = sdkService.setup(params);
 
         // Then
-        assertEquals("Successfully setup custom client.", response.getMessage());
+        assertEquals("Successfully setup custom client.", response.message());
 
         response = sdkService.reset(new BaseParams(sessionId));
 
-        assertEquals("", response.getMessage());
+        assertEquals("", response.message());
         assertThrows(NullPointerException.class, () -> sdkService.getClient(sessionId));
     }
 
@@ -63,7 +63,7 @@ class SdkServiceTest {
 
         SetupResponse response = sdkService.setOperator(setOperatorParams);
 
-        assertEquals("SUCCESS", response.getStatus());
+        assertEquals("SUCCESS", response.status());
         var client = sdkService.getClient(sessionId);
         assertEquals(newOperatorAccountId, client.getOperatorAccountId());
         assertEquals(newOperatorKey.getPublicKey(), client.getOperatorPublicKey());

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponseTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/ContractCallResponseTest.java
@@ -3,9 +3,7 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import static com.hedera.hashgraph.tck.methods.ResponseSerializationTestHelper.serializeToJson;
 
-import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
-import com.hedera.hashgraph.sdk.Hbar;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -20,8 +18,8 @@ public class ContractCallResponseTest {
                 1L,
                 List.of(),
                 10L,
-                Hbar.from(1),
-                AccountId.fromString("0.0.2"),
+                "1th",
+                "0.0.2",
                 1L,
                 "resultData");
         var json = serializeToJson(response);
@@ -33,10 +31,8 @@ public class ContractCallResponseTest {
         Assertions.assertTrue(json.contains("\"gasUsed\":1"));
         Assertions.assertTrue(json.contains("\"logs\":[]"));
         Assertions.assertTrue(json.contains("\"gas\":10"));
-        Assertions.assertTrue(json.contains("\"hbarAmount\":{\"valueInTinybar\":100000000}"));
-        Assertions.assertTrue(
-                json.contains(
-                        "\"senderAccountId\":{\"shard\":0,\"realm\":0,\"num\":2,\"aliasKey\":null,\"evmAddress\":null,\"checksum\":null}"));
+        Assertions.assertTrue(json.contains("\"hbarAmount\":\"1th\""));
+        Assertions.assertTrue(json.contains("\"senderAccountId\":\"0.0.2\""));
         Assertions.assertTrue(json.contains("\"signerNonce\":1"));
         Assertions.assertTrue(json.contains("\"rawResult\":\"resultData\""));
     }

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponseTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/GenerateKeyResponseTest.java
@@ -3,6 +3,7 @@ package com.hedera.hashgraph.tck.methods.sdk.response;
 
 import static com.hedera.hashgraph.tck.methods.ResponseSerializationTestHelper.serializeToJson;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -10,10 +11,7 @@ import org.junit.jupiter.api.Test;
 public class GenerateKeyResponseTest {
     @Test
     void shouldSerializeGenerateKeyResponseWithAllFields() {
-        var response = new GenerateKeyResponse();
-        // TODO: All args constructor missing, update this to use constructor once converted to record
-        response.setKey("testKey");
-        response.setPrivateKeys(List.of("key1", "key2"));
+        var response = new GenerateKeyResponse("testKey", List.of("key1", "key2"));
         var json = serializeToJson(response);
 
         Assertions.assertTrue(json.contains("\"key\":\"testKey\""));
@@ -22,7 +20,7 @@ public class GenerateKeyResponseTest {
 
     @Test
     void shouldSerializeGenerateKeyResponseNullFields() {
-        var response = new GenerateKeyResponse();
+        var response = new GenerateKeyResponse(null, new ArrayList<>());
         var json = serializeToJson(response);
 
         Assertions.assertTrue(json.contains("\"key\":null"));

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponseTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/response/SetupResponseTest.java
@@ -20,8 +20,8 @@ class SetupResponseTest {
 
         // Then
         assertNotNull(setupResponse);
-        assertEquals(message, setupResponse.getMessage());
-        assertEquals("SUCCESS", setupResponse.getStatus());
+        assertEquals(message, setupResponse.message());
+        assertEquals("SUCCESS", setupResponse.status());
     }
 
     @Test
@@ -34,8 +34,8 @@ class SetupResponseTest {
 
         // Then
         assertNotNull(setupResponse);
-        assertEquals("", setupResponse.getMessage()); // message should default to empty string
-        assertEquals("SUCCESS", setupResponse.getStatus());
+        assertEquals("", setupResponse.message()); // message should default to empty string
+        assertEquals("SUCCESS", setupResponse.status());
     }
 
     @Test
@@ -48,8 +48,8 @@ class SetupResponseTest {
 
         // Then
         assertNotNull(setupResponse);
-        assertEquals("", setupResponse.getMessage());
-        assertEquals("SUCCESS", setupResponse.getStatus());
+        assertEquals("", setupResponse.message());
+        assertEquals("SUCCESS", setupResponse.status());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR converts the tck response classes to the records

**Related issue(s)**:

Fixes #2891

**Notes for reviewer**:
- Updated parameters type for `ContractCallResponse` class to use string instead of raw Hbar and AccountId class.
- Tested against hiero-sdk-tck with solo version `0.87.1`
<img width="1875" height="300" alt="Screenshot From 2026-08-30 18-38-03" src="https://github.com/user-attachments/assets/f4856f73-5e57-46a5-b919-51b2e6e5cb57" />


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
