### PR TITLE
fix: correct ntf to nft typo in NftId javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
@@ -48,7 +48,7 @@ public class NftId implements Comparable<NftId> {
     }
 
     /**
-     * Create a new ntf id from a protobuf.
+     * Create a new nft id from a protobuf.
      *
      * @param nftId                     the protobuf representation
      * @return                          the new nft id


### PR DESCRIPTION
## Description

Fixes a typo in the NftId.java javadoc (line 51): 
tf → 
ft.

This PR resolves #2923.

## Changes

- [sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java](https://github.com/hiero-ledger/hiero-sdk-java/blob/main/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java): Create a new ntf id from a protobuf. → Create a new nft id from a protobuf.

## Compliance checklist

- [x] Commit is GPG signed (git commit -S)
- [x] Commit is DCO signed-off (git commit -s)
- [x] Javadoc-only change — no functional code affected