### PR TITLE
chore(sdk): resolve #2925 typo in BaseNodeAddress.java

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
@@ -52,7 +52,7 @@ class BaseNodeAddress {
     }
 
     /**
-     * Create a managed node address fom a string.
+     * Create a managed node address from a string.
      *
      * @param string                    the string representation
      * @return                          the new managed node address


### PR DESCRIPTION
## Summary
Fixed a typo in the JavaDoc comment for the `fromString()` method in `BaseNodeAddress.java`.

## Problem
The JavaDoc comment incorrectly spelled "from" as "fom" (line 55).

## Changes
- Corrected typo: "fom a string" → "from a string" in `sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java`
- Added `CHANGES.md` describing the fix

## Testing
- The change is a comment-only fix with no functional impact.
- Gradle build could not fully complete due to network/download restrictions in this environment, but the file edit is correct.

## Documentation
Added `CHANGES.md` describing the issue, fix, and testing.

Closes #2925