### PR TITLE
fix: correct 'fom' to 'from' typo in BaseNodeAddress javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
@@ -52,7 +52,7 @@ class BaseNodeAddress {
     }
 
     /**
-     * Create a managed node address fom a string.
+     * Create a managed node address from a string.
      *
      * @param string                    the string representation
      * @return                          the new managed node address


### PR DESCRIPTION
## Description
Fixes a typo in the javadoc comment of `BaseNodeAddress.java`:
- `fom` → `from` on line 55

## Checklist
- [x] I have read the issue and understand the requirements
- [x] I have signed my commits (DCO)
- [x] This is a simple one-line typo fix in a javadoc comment

Fixes #2925