### PR TITLE
docs: correct ntf to nft typo in NftId javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
@@ -48,7 +48,7 @@ public class NftId implements Comparable<NftId> {
     }
 
     /**
-     * Create a new ntf id from a protobuf.
+     * Create a new nft id from a protobuf.
      *
      * @param nftId                     the protobuf representation
      * @return                          the new nft id


### PR DESCRIPTION
**Description**:
Fixes a typo on line 51 of NftId.java where "ntf" was incorrectly used instead of "nft" in the javadoc comment.

**Related issue(s)**:
Fixes #2923

**Notes for reviewer**:
Simple one-line javadoc typo fix, no functional changes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)