### PR TITLE
fix: correct 'fom' to 'from' typo in BaseNodeAddress javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
@@ -52,7 +52,7 @@ class BaseNodeAddress {
     }
 
     /**
-     * Create a managed node address fom a string.
+     * Create a managed node address from a string.
      *
      * @param string                    the string representation
      * @return                          the new managed node address


### PR DESCRIPTION
Fixes: hiero-ledger/hiero-sdk-java#2925