### PR TITLE
chore: Replace reflective no-arg instantiation of JSON-RPC parameters with a typed parser registry

### DIFF
--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
@@ -122,7 +122,7 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
         for (int i = 0; i < paramTypes.length; i++) {
             try {
                 args[i] = JSONRPC2ParamRegistry.parse(paramTypes[i], jrpcParams);
-            } catch (Exception e) {
+            } catch (InvalidJSONRPC2ParamsException e) {
                 throw new InvalidJSONRPC2ParamsException("Invalid parameters for method %s with args: %s"
                         .formatted(method.getName(), Arrays.toString(args)));
             }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import net.minidev.json.JSONObject;
 
 /**
@@ -34,6 +35,7 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
     // this is shared state to all requests so there could be race conditions
     // although the tck driver would not call these methods in such way
     private final Map<String, Method> methodMap;
+    private static final Map<Class<?>, Function<Map<String, Object>, ?>> paramRegistry = JSONRPC2ParamRegistry.create();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -122,10 +124,8 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
         Object[] args = new Object[paramTypes.length];
         for (int i = 0; i < paramTypes.length; i++) {
             try {
-                var paramInstance = paramTypes[i].newInstance();
-                if (paramInstance instanceof JSONRPC2Param jsonRpcParam) {
-                    args[i] = jsonRpcParam.parse(jrpcParams);
-                }
+                var paramInstance = paramRegistry.get(paramTypes[i]);
+                args[i] = paramInstance.apply(jrpcParams);
             } catch (Exception e) {
                 throw new InvalidJSONRPC2ParamsException("Invalid parameters for method %s with args: %s"
                         .formatted(method.getName(), Arrays.toString(args)));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import net.minidev.json.JSONObject;
 
 /**
@@ -35,7 +34,6 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
     // this is shared state to all requests so there could be race conditions
     // although the tck driver would not call these methods in such way
     private final Map<String, Method> methodMap;
-    private static final Map<Class<?>, Function<Map<String, Object>,? extends JSONRPC2Param>> paramRegistry = JSONRPC2ParamRegistry.create();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -123,8 +121,7 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
         Object[] args = new Object[paramTypes.length];
         for (int i = 0; i < paramTypes.length; i++) {
             try {
-                var paramInstance = paramRegistry.get(paramTypes[i]);
-                args[i] = paramInstance.apply(jrpcParams);
+                args[i] = JSONRPC2ParamRegistry.parse(paramTypes[i], jrpcParams);
             } catch (Exception e) {
                 throw new InvalidJSONRPC2ParamsException("Invalid parameters for method %s with args: %s"
                         .formatted(method.getName(), Arrays.toString(args)));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/AbstractJSONRPC2Service.java
@@ -35,7 +35,7 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
     // this is shared state to all requests so there could be race conditions
     // although the tck driver would not call these methods in such way
     private final Map<String, Method> methodMap;
-    private static final Map<Class<?>, Function<Map<String, Object>, ?>> paramRegistry = JSONRPC2ParamRegistry.create();
+    private static final Map<Class<?>, Function<Map<String, Object>,? extends JSONRPC2Param>> paramRegistry = JSONRPC2ParamRegistry.create();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -68,7 +68,6 @@ public abstract class AbstractJSONRPC2Service implements RequestHandler {
      * @param messageContext
      * @return JSONRPC2Response - result returned from the JSONRPCMethod or if error is thrown - JSONRPC2Error
      */
-    @SuppressWarnings("java:S1874")
     @Override
     public JSONRPC2Response process(final JSONRPC2Request req, final MessageContext messageContext) {
         try {

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
@@ -10,6 +10,8 @@ package com.hedera.hashgraph.tck.methods;
  * <p>
  * IMPORTANT:
  * all inheriting classes should include the following method signature:
- * <pre>public static JSONRPC2Param parse(Map<String, Object> params){}</pre>
+ * <pre>{@code
+ * public static JSONRPC2Param parse(Map<String, Object> params)
+ * }</pre>
  */
 public interface JSONRPC2Param {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
@@ -1,19 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods;
 
-import java.util.Map;
-
-/**
- * Abstract base class for JSON-RPC parameters. Every parameter POJO should extend this class
- * and implement the {@link #parse} method. This method assists JSON-RPC services in creating
- * parameters for their JSON-RPC methods from the request.
- *
- * IMPORTANT:
- * all inheriting classes should include the following Lombok annotations:
- * {@code @Getter}, {@code @AllArgsConstructor}, and {@code @NoArgsConstructor}.
- * These annotations are needed for the instance creation via reflection.
- *
- */
-public abstract class JSONRPC2Param {
-    public abstract JSONRPC2Param parse(final Map<String, Object> jrpcParams) throws Exception;
-}
+public interface JSONRPC2Param {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2Param.java
@@ -1,4 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.tck.methods;
 
+/**
+ * Marker interface for JSON-RPC parameter types.
+ * Implementations represent the parameters accepted by JSON-RPC methods. This interface
+ * intentionally does not define any methods. Each parameter implementation
+ * provides its own type-specific parsing logic.
+ *
+ * <p>
+ * IMPORTANT:
+ * all inheriting classes should include the following method signature:
+ * <pre>public static JSONRPC2Param parse(Map<String, Object> params){}</pre>
+ */
 public interface JSONRPC2Param {}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
@@ -3,6 +3,7 @@ package com.hedera.hashgraph.tck.methods;
 
 import static java.util.Map.entry;
 
+import com.hedera.hashgraph.tck.exception.InvalidJSONRPC2ParamsException;
 import com.hedera.hashgraph.tck.methods.sdk.param.BaseParams;
 import com.hedera.hashgraph.tck.methods.sdk.param.CustomFee;
 import com.hedera.hashgraph.tck.methods.sdk.param.GenerateKeyParams;
@@ -155,10 +156,12 @@ public final class JSONRPC2ParamRegistry {
      * @param params the JSON-RPC request parameters to parse
      * @return the parsed JSON-RPC parameter
      */
-    public static JSONRPC2Param parse(Class<?> parameterType, Map<String, Object> params) {
+    public static JSONRPC2Param parse(Class<?> parameterType, Map<String, Object> params)
+            throws InvalidJSONRPC2ParamsException {
         Function<Map<String, Object>, ? extends JSONRPC2Param> parser = REGISTRY.get(parameterType);
         if (parser == null) {
-            throw new IllegalArgumentException("No parser registered for parameter type: " + parameterType.getName());
+            throw new InvalidJSONRPC2ParamsException(
+                    "No parser registered for parameter type: " + parameterType.getName());
         }
 
         return parser.apply(params);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.hashgraph.tck.methods;
+
+import static java.util.Map.entry;
+
+import com.hedera.hashgraph.tck.methods.sdk.param.BaseParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.CustomFee;
+import com.hedera.hashgraph.tck.methods.sdk.param.GenerateKeyParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.SetupParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.TransactionReceiptQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountAllowanceParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountBalanceQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountCreateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountDeleteParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountUpdateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.GetAccountInfoParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.ContractByteCodeQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.ContractCallQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.CreateContractParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.DeleteContractParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.ExecuteContractParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.InfoQueryContractParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.contract.UpdateContractParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.ethereum.EthereumTransactionParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileAppendParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileContentsParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileCreateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileDeleteParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileInfoQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.file.FileUpdateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.node.AddressBookQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.node.NodeCreateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.node.NodeDeleteParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.node.NodeUpdateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.schedule.ScheduleCreateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.schedule.ScheduleDeleteParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.schedule.ScheduleInfoParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.schedule.ScheduleSignParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.AssociateDisassociateTokenParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.BurnTokenParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.FreezeUnfreezeTokenParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.GrantRevokeTokenKycParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.MintTokenParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.NftInfoQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.PauseUnpauseTokenParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenAirdropCancelParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenAirdropParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenClaimAirdropParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenCreateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenDeleteParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenInfoQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenRejectAirdropParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenUpdateFeeScheduleParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenUpdateParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.token.TokenWipeParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.CreateTopicParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.CustomFeeLimit;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.DeleteTopicParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.SubmitTopicMessageParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.TopicInfoQueryParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.topic.UpdateTopicParams;
+import com.hedera.hashgraph.tck.methods.sdk.param.transfer.TransferCryptoParams;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import org.jspecify.annotations.NonNull;
+
+public final class JSONRPC2ParamRegistry {
+    private JSONRPC2ParamRegistry() {}
+
+    @FunctionalInterface
+    public interface CheckedFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    public static <T, R> Function<T, R> unchecked(@NonNull CheckedFunction<T, R> function) {
+        Objects.requireNonNull(function, "function must not be null");
+
+        return args -> {
+            try {
+                return function.apply(args);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse JSON-RPC parameters");
+            }
+        };
+    }
+
+    public static Map<Class<?>, Function<Map<String, Object>, ?>> create() {
+        return Map.ofEntries(
+                entry(BaseParams.class, unchecked(BaseParams::parse)),
+                entry(SetupParams.class, unchecked(SetupParams::parse)),
+                entry(GenerateKeyParams.class, unchecked(GenerateKeyParams::parse)),
+                entry(TransactionReceiptQueryParams.class, unchecked(TransactionReceiptQueryParams::parse)),
+                entry(CustomFee.class, unchecked(CustomFee::parse)),
+                entry(AccountAllowanceParams.class, unchecked(AccountAllowanceParams::parse)),
+                entry(AccountBalanceQueryParams.class, unchecked(AccountBalanceQueryParams::parse)),
+                entry(AccountCreateParams.class, unchecked(AccountCreateParams::parse)),
+                entry(AccountDeleteParams.class, unchecked(AccountDeleteParams::parse)),
+                entry(AccountUpdateParams.class, unchecked(AccountUpdateParams::parse)),
+                entry(GetAccountInfoParams.class, unchecked(GetAccountInfoParams::parse)),
+                entry(ContractByteCodeQueryParams.class, unchecked(ContractByteCodeQueryParams::parse)),
+                entry(ContractCallQueryParams.class, unchecked(ContractCallQueryParams::parse)),
+                entry(CreateContractParams.class, unchecked(CreateContractParams::parse)),
+                entry(DeleteContractParams.class, unchecked(DeleteContractParams::parse)),
+                entry(ExecuteContractParams.class, unchecked(ExecuteContractParams::parse)),
+                entry(InfoQueryContractParams.class, unchecked(InfoQueryContractParams::parse)),
+                entry(UpdateContractParams.class, unchecked(UpdateContractParams::parse)),
+                entry(EthereumTransactionParams.class, unchecked(EthereumTransactionParams::parse)),
+                entry(FileAppendParams.class, unchecked(FileAppendParams::parse)),
+                entry(FileContentsParams.class, unchecked(FileContentsParams::parse)),
+                entry(FileCreateParams.class, unchecked(FileCreateParams::parse)),
+                entry(FileDeleteParams.class, unchecked(FileDeleteParams::parse)),
+                entry(FileInfoQueryParams.class, unchecked(FileInfoQueryParams::parse)),
+                entry(FileUpdateParams.class, unchecked(FileUpdateParams::parse)),
+                entry(AddressBookQueryParams.class, unchecked(AddressBookQueryParams::parse)),
+                entry(NodeCreateParams.class, unchecked(NodeCreateParams::parse)),
+                entry(NodeDeleteParams.class, unchecked(NodeDeleteParams::parse)),
+                entry(NodeUpdateParams.class, unchecked(NodeUpdateParams::parse)),
+                entry(ScheduleCreateParams.class, unchecked(ScheduleCreateParams::parse)),
+                entry(ScheduleDeleteParams.class, unchecked(ScheduleDeleteParams::parse)),
+                entry(ScheduleInfoParams.class, unchecked(ScheduleInfoParams::parse)),
+                entry(ScheduleSignParams.class, unchecked(ScheduleSignParams::parse)),
+                entry(AssociateDisassociateTokenParams.class, unchecked(AssociateDisassociateTokenParams::parse)),
+                entry(BurnTokenParams.class, unchecked(BurnTokenParams::parse)),
+                entry(FreezeUnfreezeTokenParams.class, unchecked(FreezeUnfreezeTokenParams::parse)),
+                entry(GrantRevokeTokenKycParams.class, unchecked(GrantRevokeTokenKycParams::parse)),
+                entry(MintTokenParams.class, unchecked(MintTokenParams::parse)),
+                entry(NftInfoQueryParams.class, unchecked(NftInfoQueryParams::parse)),
+                entry(PauseUnpauseTokenParams.class, unchecked(PauseUnpauseTokenParams::parse)),
+                entry(TokenAirdropCancelParams.class, unchecked(TokenAirdropCancelParams::parse)),
+                entry(TokenAirdropParams.class, unchecked(TokenAirdropParams::parse)),
+                entry(TokenClaimAirdropParams.class, unchecked(TokenClaimAirdropParams::parse)),
+                entry(TokenCreateParams.class, unchecked(TokenCreateParams::parse)),
+                entry(TokenDeleteParams.class, unchecked(TokenDeleteParams::parse)),
+                entry(TokenInfoQueryParams.class, unchecked(TokenInfoQueryParams::parse)),
+                entry(TokenRejectAirdropParams.class, unchecked(TokenRejectAirdropParams::parse)),
+                entry(TokenUpdateFeeScheduleParams.class, unchecked(TokenUpdateFeeScheduleParams::parse)),
+                entry(TokenUpdateParams.class, unchecked(TokenUpdateParams::parse)),
+                entry(TokenWipeParams.class, unchecked(TokenWipeParams::parse)),
+                entry(CreateTopicParams.class, unchecked(CreateTopicParams::parse)),
+                entry(CustomFeeLimit.class, unchecked(CustomFeeLimit::parse)),
+                entry(DeleteTopicParams.class, unchecked(DeleteTopicParams::parse)),
+                entry(SubmitTopicMessageParams.class, unchecked(SubmitTopicMessageParams::parse)),
+                entry(TopicInfoQueryParams.class, unchecked(TopicInfoQueryParams::parse)),
+                entry(UpdateTopicParams.class, unchecked(UpdateTopicParams::parse)),
+                entry(TransferCryptoParams.class, unchecked(TransferCryptoParams::parse)));
+    }
+}

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
@@ -65,84 +65,133 @@ import java.util.Objects;
 import java.util.function.Function;
 import org.jspecify.annotations.NonNull;
 
+/**
+ * Registry of JSON-RPC parameter parsers.
+ * <p>
+ * Each registered parameter type is associated with a parser that converts the
+ * JSON-RPC request parameters into an instance of that type. Parameter classes are
+ * responsible for defining their own {@code parse} method, while this registry
+ * provides the mapping between parameter types and their parsers.
+ *
+ */
 public final class JSONRPC2ParamRegistry {
+    private static final Map<Class<?>, Function<Map<String, Object>, ? extends JSONRPC2Param>> REGISTRY =
+            initRegistry();
+
     private JSONRPC2ParamRegistry() {}
 
-    @FunctionalInterface
-    public interface CheckedFunction<T, R> {
-        R apply(T t) throws Exception;
+    /**
+     * Initializes the JSON-RPC parameter parser registry.
+     *
+     * @return the initialized parser registry
+     */
+    private static Map<Class<?>, Function<Map<String, Object>, ? extends JSONRPC2Param>> initRegistry() {
+        return Map.<Class<?>, Function<Map<String, Object>, ? extends JSONRPC2Param>>ofEntries(
+                entry(BaseParams.class, toUncheckedFunction(BaseParams::parse)),
+                entry(SetupParams.class, toUncheckedFunction(SetupParams::parse)),
+                entry(GenerateKeyParams.class, toUncheckedFunction(GenerateKeyParams::parse)),
+                entry(TransactionReceiptQueryParams.class, toUncheckedFunction(TransactionReceiptQueryParams::parse)),
+                entry(CustomFee.class, toUncheckedFunction(CustomFee::parse)),
+                entry(AccountAllowanceParams.class, toUncheckedFunction(AccountAllowanceParams::parse)),
+                entry(AccountBalanceQueryParams.class, toUncheckedFunction(AccountBalanceQueryParams::parse)),
+                entry(AccountCreateParams.class, toUncheckedFunction(AccountCreateParams::parse)),
+                entry(AccountDeleteParams.class, toUncheckedFunction(AccountDeleteParams::parse)),
+                entry(AccountUpdateParams.class, toUncheckedFunction(AccountUpdateParams::parse)),
+                entry(GetAccountInfoParams.class, toUncheckedFunction(GetAccountInfoParams::parse)),
+                entry(ContractByteCodeQueryParams.class, toUncheckedFunction(ContractByteCodeQueryParams::parse)),
+                entry(ContractCallQueryParams.class, toUncheckedFunction(ContractCallQueryParams::parse)),
+                entry(CreateContractParams.class, toUncheckedFunction(CreateContractParams::parse)),
+                entry(DeleteContractParams.class, toUncheckedFunction(DeleteContractParams::parse)),
+                entry(ExecuteContractParams.class, toUncheckedFunction(ExecuteContractParams::parse)),
+                entry(InfoQueryContractParams.class, toUncheckedFunction(InfoQueryContractParams::parse)),
+                entry(UpdateContractParams.class, toUncheckedFunction(UpdateContractParams::parse)),
+                entry(EthereumTransactionParams.class, toUncheckedFunction(EthereumTransactionParams::parse)),
+                entry(FileAppendParams.class, toUncheckedFunction(FileAppendParams::parse)),
+                entry(FileContentsParams.class, toUncheckedFunction(FileContentsParams::parse)),
+                entry(FileCreateParams.class, toUncheckedFunction(FileCreateParams::parse)),
+                entry(FileDeleteParams.class, toUncheckedFunction(FileDeleteParams::parse)),
+                entry(FileInfoQueryParams.class, toUncheckedFunction(FileInfoQueryParams::parse)),
+                entry(FileUpdateParams.class, toUncheckedFunction(FileUpdateParams::parse)),
+                entry(AddressBookQueryParams.class, toUncheckedFunction(AddressBookQueryParams::parse)),
+                entry(NodeCreateParams.class, toUncheckedFunction(NodeCreateParams::parse)),
+                entry(NodeDeleteParams.class, toUncheckedFunction(NodeDeleteParams::parse)),
+                entry(NodeUpdateParams.class, toUncheckedFunction(NodeUpdateParams::parse)),
+                entry(ScheduleCreateParams.class, toUncheckedFunction(ScheduleCreateParams::parse)),
+                entry(ScheduleDeleteParams.class, toUncheckedFunction(ScheduleDeleteParams::parse)),
+                entry(ScheduleInfoParams.class, toUncheckedFunction(ScheduleInfoParams::parse)),
+                entry(ScheduleSignParams.class, toUncheckedFunction(ScheduleSignParams::parse)),
+                entry(
+                        AssociateDisassociateTokenParams.class,
+                        toUncheckedFunction(AssociateDisassociateTokenParams::parse)),
+                entry(BurnTokenParams.class, toUncheckedFunction(BurnTokenParams::parse)),
+                entry(FreezeUnfreezeTokenParams.class, toUncheckedFunction(FreezeUnfreezeTokenParams::parse)),
+                entry(GrantRevokeTokenKycParams.class, toUncheckedFunction(GrantRevokeTokenKycParams::parse)),
+                entry(MintTokenParams.class, toUncheckedFunction(MintTokenParams::parse)),
+                entry(NftInfoQueryParams.class, toUncheckedFunction(NftInfoQueryParams::parse)),
+                entry(PauseUnpauseTokenParams.class, toUncheckedFunction(PauseUnpauseTokenParams::parse)),
+                entry(TokenAirdropCancelParams.class, toUncheckedFunction(TokenAirdropCancelParams::parse)),
+                entry(TokenAirdropParams.class, toUncheckedFunction(TokenAirdropParams::parse)),
+                entry(TokenClaimAirdropParams.class, toUncheckedFunction(TokenClaimAirdropParams::parse)),
+                entry(TokenCreateParams.class, toUncheckedFunction(TokenCreateParams::parse)),
+                entry(TokenDeleteParams.class, toUncheckedFunction(TokenDeleteParams::parse)),
+                entry(TokenInfoQueryParams.class, toUncheckedFunction(TokenInfoQueryParams::parse)),
+                entry(TokenRejectAirdropParams.class, toUncheckedFunction(TokenRejectAirdropParams::parse)),
+                entry(TokenUpdateFeeScheduleParams.class, toUncheckedFunction(TokenUpdateFeeScheduleParams::parse)),
+                entry(TokenUpdateParams.class, toUncheckedFunction(TokenUpdateParams::parse)),
+                entry(TokenWipeParams.class, toUncheckedFunction(TokenWipeParams::parse)),
+                entry(CreateTopicParams.class, toUncheckedFunction(CreateTopicParams::parse)),
+                entry(CustomFeeLimit.class, toUncheckedFunction(CustomFeeLimit::parse)),
+                entry(DeleteTopicParams.class, toUncheckedFunction(DeleteTopicParams::parse)),
+                entry(SubmitTopicMessageParams.class, toUncheckedFunction(SubmitTopicMessageParams::parse)),
+                entry(TopicInfoQueryParams.class, toUncheckedFunction(TopicInfoQueryParams::parse)),
+                entry(UpdateTopicParams.class, toUncheckedFunction(UpdateTopicParams::parse)),
+                entry(TransferCryptoParams.class, toUncheckedFunction(TransferCryptoParams::parse)));
     }
 
-    public static <T, R extends JSONRPC2Param> Function<T, R> unchecked(@NonNull CheckedFunction<T, R> function) {
+    /**
+     * Parses JSON-RPC parameters using the parser registered for the given parameter type.
+     *
+     * @param parameterType the parameter type whose registered parser should be used
+     * @param params the JSON-RPC request parameters to parse
+     * @return the parsed JSON-RPC parameter
+     */
+    public static JSONRPC2Param parse(Class<?> parameterType, Map<String, Object> params) {
+        Function<Map<String, Object>, ? extends JSONRPC2Param> parser = REGISTRY.get(parameterType);
+        if (parser == null) {
+            throw new IllegalArgumentException("No parser registered for parameter type: " + parameterType.getName());
+        }
+
+        return parser.apply(params);
+    }
+
+    /**
+     * Helper functional interface for functions that throw a checked exception.
+     *
+     * @param <InputType> the input type
+     * @param <ReturnType> the return type
+     */
+    @FunctionalInterface
+    private interface CheckedFunction<InputType, ReturnType> {
+        ReturnType apply(InputType input) throws Exception;
+    }
+
+    /**
+     * Converts a {@link CheckedFunction} into a standard {@link Function}.
+     *
+     * @param function the checked function to convert
+     * @return a function that delegates to the supplied checked function
+     * @throws IllegalArgumentException if the checked function fail to parse the params
+     */
+    private static <InputType, ReturnType extends JSONRPC2Param> Function<InputType, ReturnType> toUncheckedFunction(
+            @NonNull CheckedFunction<InputType, ReturnType> function) {
         Objects.requireNonNull(function, "function must not be null");
 
         return args -> {
             try {
                 return function.apply(args);
             } catch (Exception e) {
-                throw new RuntimeException("Failed to parse JSON-RPC parameters");
+                throw new IllegalArgumentException("Failed to parse JSON-RPC parameters");
             }
         };
-    }
-
-    public static Map<Class<?>, Function<Map<String, Object>, ? extends JSONRPC2Param>> create() {
-        return Map.<Class<?>, Function<Map<String, Object>, ?>>ofEntries(
-                entry(BaseParams.class, unchecked(BaseParams::parse)),
-                entry(SetupParams.class, unchecked(SetupParams::parse)),
-                entry(GenerateKeyParams.class, unchecked(GenerateKeyParams::parse)),
-                entry(TransactionReceiptQueryParams.class, unchecked(TransactionReceiptQueryParams::parse)),
-                entry(CustomFee.class, unchecked(CustomFee::parse)),
-                entry(AccountAllowanceParams.class, unchecked(AccountAllowanceParams::parse)),
-                entry(AccountBalanceQueryParams.class, unchecked(AccountBalanceQueryParams::parse)),
-                entry(AccountCreateParams.class, unchecked(AccountCreateParams::parse)),
-                entry(AccountDeleteParams.class, unchecked(AccountDeleteParams::parse)),
-                entry(AccountUpdateParams.class, unchecked(AccountUpdateParams::parse)),
-                entry(GetAccountInfoParams.class, unchecked(GetAccountInfoParams::parse)),
-                entry(ContractByteCodeQueryParams.class, unchecked(ContractByteCodeQueryParams::parse)),
-                entry(ContractCallQueryParams.class, unchecked(ContractCallQueryParams::parse)),
-                entry(CreateContractParams.class, unchecked(CreateContractParams::parse)),
-                entry(DeleteContractParams.class, unchecked(DeleteContractParams::parse)),
-                entry(ExecuteContractParams.class, unchecked(ExecuteContractParams::parse)),
-                entry(InfoQueryContractParams.class, unchecked(InfoQueryContractParams::parse)),
-                entry(UpdateContractParams.class, unchecked(UpdateContractParams::parse)),
-                entry(EthereumTransactionParams.class, unchecked(EthereumTransactionParams::parse)),
-                entry(FileAppendParams.class, unchecked(FileAppendParams::parse)),
-                entry(FileContentsParams.class, unchecked(FileContentsParams::parse)),
-                entry(FileCreateParams.class, unchecked(FileCreateParams::parse)),
-                entry(FileDeleteParams.class, unchecked(FileDeleteParams::parse)),
-                entry(FileInfoQueryParams.class, unchecked(FileInfoQueryParams::parse)),
-                entry(FileUpdateParams.class, unchecked(FileUpdateParams::parse)),
-                entry(AddressBookQueryParams.class, unchecked(AddressBookQueryParams::parse)),
-                entry(NodeCreateParams.class, unchecked(NodeCreateParams::parse)),
-                entry(NodeDeleteParams.class, unchecked(NodeDeleteParams::parse)),
-                entry(NodeUpdateParams.class, unchecked(NodeUpdateParams::parse)),
-                entry(ScheduleCreateParams.class, unchecked(ScheduleCreateParams::parse)),
-                entry(ScheduleDeleteParams.class, unchecked(ScheduleDeleteParams::parse)),
-                entry(ScheduleInfoParams.class, unchecked(ScheduleInfoParams::parse)),
-                entry(ScheduleSignParams.class, unchecked(ScheduleSignParams::parse)),
-                entry(AssociateDisassociateTokenParams.class, unchecked(AssociateDisassociateTokenParams::parse)),
-                entry(BurnTokenParams.class, unchecked(BurnTokenParams::parse)),
-                entry(FreezeUnfreezeTokenParams.class, unchecked(FreezeUnfreezeTokenParams::parse)),
-                entry(GrantRevokeTokenKycParams.class, unchecked(GrantRevokeTokenKycParams::parse)),
-                entry(MintTokenParams.class, unchecked(MintTokenParams::parse)),
-                entry(NftInfoQueryParams.class, unchecked(NftInfoQueryParams::parse)),
-                entry(PauseUnpauseTokenParams.class, unchecked(PauseUnpauseTokenParams::parse)),
-                entry(TokenAirdropCancelParams.class, unchecked(TokenAirdropCancelParams::parse)),
-                entry(TokenAirdropParams.class, unchecked(TokenAirdropParams::parse)),
-                entry(TokenClaimAirdropParams.class, unchecked(TokenClaimAirdropParams::parse)),
-                entry(TokenCreateParams.class, unchecked(TokenCreateParams::parse)),
-                entry(TokenDeleteParams.class, unchecked(TokenDeleteParams::parse)),
-                entry(TokenInfoQueryParams.class, unchecked(TokenInfoQueryParams::parse)),
-                entry(TokenRejectAirdropParams.class, unchecked(TokenRejectAirdropParams::parse)),
-                entry(TokenUpdateFeeScheduleParams.class, unchecked(TokenUpdateFeeScheduleParams::parse)),
-                entry(TokenUpdateParams.class, unchecked(TokenUpdateParams::parse)),
-                entry(TokenWipeParams.class, unchecked(TokenWipeParams::parse)),
-                entry(CreateTopicParams.class, unchecked(CreateTopicParams::parse)),
-                entry(CustomFeeLimit.class, unchecked(CustomFeeLimit::parse)),
-                entry(DeleteTopicParams.class, unchecked(DeleteTopicParams::parse)),
-                entry(SubmitTopicMessageParams.class, unchecked(SubmitTopicMessageParams::parse)),
-                entry(TopicInfoQueryParams.class, unchecked(TopicInfoQueryParams::parse)),
-                entry(UpdateTopicParams.class, unchecked(UpdateTopicParams::parse)),
-                entry(TransferCryptoParams.class, unchecked(TransferCryptoParams::parse)));
     }
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamRegistry.java
@@ -73,7 +73,7 @@ public final class JSONRPC2ParamRegistry {
         R apply(T t) throws Exception;
     }
 
-    public static <T, R> Function<T, R> unchecked(@NonNull CheckedFunction<T, R> function) {
+    public static <T, R extends JSONRPC2Param> Function<T, R> unchecked(@NonNull CheckedFunction<T, R> function) {
         Objects.requireNonNull(function, "function must not be null");
 
         return args -> {
@@ -85,8 +85,8 @@ public final class JSONRPC2ParamRegistry {
         };
     }
 
-    public static Map<Class<?>, Function<Map<String, Object>, ?>> create() {
-        return Map.ofEntries(
+    public static Map<Class<?>, Function<Map<String, Object>, ? extends JSONRPC2Param>> create() {
+        return Map.<Class<?>, Function<Map<String, Object>, ?>>ofEntries(
                 entry(BaseParams.class, unchecked(BaseParams::parse)),
                 entry(SetupParams.class, unchecked(SetupParams::parse)),
                 entry(GenerateKeyParams.class, unchecked(GenerateKeyParams::parse)),

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/BaseParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/BaseParams.java
@@ -6,19 +6,16 @@ import com.hedera.hashgraph.tck.util.JSONRPCParamParser;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * Base parameters that carry the session identifier for JSON-RPC calls.
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class BaseParams extends JSONRPC2Param {
+public class BaseParams implements JSONRPC2Param {
     private String sessionId;
 
-    @Override
-    public BaseParams parse(Map<String, Object> jrpcParams) {
+    public static BaseParams parse(Map<String, Object> jrpcParams) {
         return new BaseParams(JSONRPCParamParser.parseSessionId(jrpcParams));
     }
 }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/CommonTransactionParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/CommonTransactionParams.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import net.minidev.json.JSONArray;
 
 /**
@@ -18,7 +17,6 @@ import net.minidev.json.JSONArray;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class CommonTransactionParams {
     private Optional<String> transactionId;
     private Optional<Long> maxTransactionFee;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/CustomFee.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/CustomFee.java
@@ -15,8 +15,7 @@ import net.minidev.json.JSONObject;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class CustomFee extends JSONRPC2Param {
+public class CustomFee implements JSONRPC2Param {
 
     private String feeCollectorAccountId;
     private Boolean feeCollectorsExempt;
@@ -24,8 +23,7 @@ public class CustomFee extends JSONRPC2Param {
     private Optional<FractionalFee> fractionalFee;
     private Optional<RoyaltyFee> royaltyFee;
 
-    @Override
-    public CustomFee parse(Map<String, Object> jrpcParams) throws Exception {
+    public static CustomFee parse(Map<String, Object> jrpcParams) throws Exception {
         var feeCollectorAccountIdParsed = (String) jrpcParams.get("feeCollectorAccountId");
         var feeCollectorsExemptParsed = (Boolean) jrpcParams.get("feeCollectorsExempt");
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/GenerateKeyParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/GenerateKeyParams.java
@@ -9,22 +9,19 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class GenerateKeyParams extends JSONRPC2Param {
+public class GenerateKeyParams implements JSONRPC2Param {
     private KeyType type;
     private Optional<String> fromKey;
     private Optional<Long> threshold;
     private Optional<List<GenerateKeyParams>> keys;
 
-    @Override
-    public GenerateKeyParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static GenerateKeyParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedType = (String) jrpcParams.get("type");
         var parsedFromKey = Optional.ofNullable((String) jrpcParams.get("fromKey"));
         var parsedThreshold = Optional.ofNullable((Long) jrpcParams.get("threshold"));
@@ -35,7 +32,7 @@ public class GenerateKeyParams extends JSONRPC2Param {
             List<GenerateKeyParams> keyList = new ArrayList<>();
             for (Object o : jsonArray) {
                 JSONObject jsonObject = (JSONObject) o;
-                GenerateKeyParams keyParam = new GenerateKeyParams().parse(jsonObject);
+                GenerateKeyParams keyParam = GenerateKeyParams.parse(jsonObject);
                 keyList.add(keyParam);
             }
             parsedKeys = Optional.of(keyList);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/SetupParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/SetupParams.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * SetupParams for SDK client
@@ -15,8 +14,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class SetupParams extends JSONRPC2Param {
+public class SetupParams implements JSONRPC2Param {
     private String operatorAccountId;
     private String operatorPrivateKey;
     private Optional<String> nodeIp;
@@ -24,8 +22,7 @@ public class SetupParams extends JSONRPC2Param {
     private Optional<String> mirrorNetworkIp;
     private String sessionId;
 
-    @Override
-    public SetupParams parse(Map<String, Object> jrpcParams) throws ClassCastException {
+    public static SetupParams parse(Map<String, Object> jrpcParams) throws ClassCastException {
         var parsedOperatorAccountId = (String) jrpcParams.get("operatorAccountId");
         var parsedOperatorPrivateKey = (String) jrpcParams.get("operatorPrivateKey");
         var parsedNodeIp = Optional.ofNullable((String) jrpcParams.get("nodeIp"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/TransactionReceiptQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/TransactionReceiptQueryParams.java
@@ -7,20 +7,17 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TransactionReceiptQueryParams extends JSONRPC2Param {
+public class TransactionReceiptQueryParams implements JSONRPC2Param {
     private String transactionId;
     private Boolean includeDuplicates;
     private Boolean includeChildren;
     private Boolean validateStatus;
     private String sessionId;
 
-    @Override
-    public TransactionReceiptQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TransactionReceiptQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         String parsedTransactionId = (String) jrpcParams.get("transactionId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountAllowanceParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountAllowanceParams.java
@@ -9,18 +9,15 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AccountAllowanceParams extends JSONRPC2Param {
+public class AccountAllowanceParams implements JSONRPC2Param {
     private Optional<List<AllowanceParams>> allowances;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AccountAllowanceParams parse(Map<String, Object> jrpcParams) throws Exception {
 
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
         var parsedAllowances = JSONRPCParamParser.parseAllowances(jrpcParams);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountBalanceQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountBalanceQueryParams.java
@@ -7,18 +7,15 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AccountBalanceQueryParams extends JSONRPC2Param {
+public class AccountBalanceQueryParams implements JSONRPC2Param {
     private Optional<String> accountId;
     private Optional<String> contractId;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AccountBalanceQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedContractId = Optional.ofNullable((String) jrpcParams.get("contractId"));
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountCreateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountCreateParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * AccountCreateParams for account create method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AccountCreateParams extends JSONRPC2Param {
+public class AccountCreateParams implements JSONRPC2Param {
     private Optional<String> key;
     private Optional<String> initialBalance;
     private Optional<Boolean> receiverSignatureRequired;
@@ -31,8 +29,7 @@ public class AccountCreateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public AccountCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AccountCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedKey = Optional.ofNullable((String) jrpcParams.get("key"));
         var parsedInitialBalance = Optional.ofNullable((String) jrpcParams.get("initialBalance"));
         var parsedReceiverSignatureRequired =

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountDeleteParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountDeleteParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * AccountDeleteParams for account delete method
@@ -16,15 +15,13 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AccountDeleteParams extends JSONRPC2Param {
+public class AccountDeleteParams implements JSONRPC2Param {
     private Optional<String> deleteAccountId;
     private Optional<String> transferAccountId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public AccountDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AccountDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedDeleteAccountId = Optional.ofNullable((String) jrpcParams.get("deleteAccountId"));
         var parsedTransferAccountId = Optional.ofNullable((String) jrpcParams.get("transferAccountId"));
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountUpdateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AccountUpdateParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * AccountUpdateParams for account update method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AccountUpdateParams extends JSONRPC2Param {
+public class AccountUpdateParams implements JSONRPC2Param {
     private Optional<String> key;
     private Optional<Boolean> receiverSignatureRequired;
     private Optional<String> autoRenewPeriod;
@@ -31,8 +29,7 @@ public class AccountUpdateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public AccountUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AccountUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedKey = Optional.ofNullable((String) jrpcParams.get("key"));
         var parsedReceiverSignatureRequired =
                 Optional.ofNullable((Boolean) jrpcParams.get("receiverSignatureRequired"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AllowanceParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/AllowanceParams.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class AllowanceParams {
 
     private Optional<String> ownerAccountId;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/GetAccountInfoParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/account/GetAccountInfoParams.java
@@ -6,20 +6,17 @@ import com.hedera.hashgraph.tck.util.JSONRPCParamParser;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * GetAccountInfoParams for account info query method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class GetAccountInfoParams extends JSONRPC2Param {
+public class GetAccountInfoParams implements JSONRPC2Param {
     private String sessionId;
     private String accountId;
 
-    @Override
-    public GetAccountInfoParams parse(Map<String, Object> jrpcParams) {
+    public static GetAccountInfoParams parse(Map<String, Object> jrpcParams) {
         return new GetAccountInfoParams(
                 JSONRPCParamParser.parseSessionId(jrpcParams), (String) jrpcParams.get("accountId"));
     }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ContractByteCodeQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ContractByteCodeQueryParams.java
@@ -7,19 +7,16 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ContractByteCodeQueryParams extends JSONRPC2Param {
+public class ContractByteCodeQueryParams implements JSONRPC2Param {
     private Optional<String> contractId;
     private Optional<String> queryPayment;
     private Optional<String> maxQueryPayment;
     private String sessionId;
 
-    @Override
-    public ContractByteCodeQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ContractByteCodeQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedContractId = Optional.ofNullable((String) jrpcParams.get("contractId"));
         var parsedQueryPayment = Optional.ofNullable((String) jrpcParams.get("queryPayment"));
         var parsedMaxQueryPayment = Optional.ofNullable((String) jrpcParams.get("maxQueryPayment"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ContractCallQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ContractCallQueryParams.java
@@ -7,12 +7,10 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ContractCallQueryParams extends JSONRPC2Param {
+public class ContractCallQueryParams implements JSONRPC2Param {
     private String contractId;
     private String gas;
     private String functionParameters;
@@ -20,8 +18,7 @@ public class ContractCallQueryParams extends JSONRPC2Param {
     private String senderAccountId;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ContractCallQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedContractId = (String) jrpcParams.get("contractId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/CreateContractParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/CreateContractParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * CreateContractParams for contract create method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class CreateContractParams extends JSONRPC2Param {
+public class CreateContractParams implements JSONRPC2Param {
     private Optional<String> adminKey;
     private Optional<String> autoRenewPeriod;
     private Optional<String> autoRenewAccountId;
@@ -34,8 +32,7 @@ public class CreateContractParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public CreateContractParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static CreateContractParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedAdminKey = Optional.ofNullable((String) jrpcParams.get("adminKey"));
         var parsedAutoRenewPeriod = Optional.ofNullable((String) jrpcParams.get("autoRenewPeriod"));
         var parsedAutoRenewAccountId = Optional.ofNullable((String) jrpcParams.get("autoRenewAccountId"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/DeleteContractParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/DeleteContractParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * DeleteContractParams for contract delete method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class DeleteContractParams extends JSONRPC2Param {
+public class DeleteContractParams implements JSONRPC2Param {
     private Optional<String> contractId;
     private Optional<String> transferAccountId;
     private Optional<String> transferContractId;
@@ -25,8 +23,7 @@ public class DeleteContractParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public DeleteContractParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static DeleteContractParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedContractId = Optional.ofNullable((String) jrpcParams.get("contractId"));
         var parsedTransferAccountId = Optional.ofNullable((String) jrpcParams.get("transferAccountId"));
         var parsedTransferContractId = Optional.ofNullable((String) jrpcParams.get("transferContractId"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ExecuteContractParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/ExecuteContractParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * ExecuteContractParams for contract execute method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ExecuteContractParams extends JSONRPC2Param {
+public class ExecuteContractParams implements JSONRPC2Param {
     private String contractId;
     private Optional<String> gas;
     private Optional<String> amount;
@@ -25,8 +23,7 @@ public class ExecuteContractParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public ExecuteContractParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ExecuteContractParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedContractId = (String) jrpcParams.get("contractId");
         var parsedGas = Optional.ofNullable((String) jrpcParams.get("gas"));
         var parsedAmount = Optional.ofNullable((String) jrpcParams.get("amount"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/InfoQueryContractParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/InfoQueryContractParams.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * InfoQueryContractParams for contract info query method
@@ -15,15 +14,13 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class InfoQueryContractParams extends JSONRPC2Param {
+public class InfoQueryContractParams implements JSONRPC2Param {
     private Optional<String> contractId;
     private Optional<String> queryPayment;
     private Optional<String> maxQueryPayment;
     private String sessionId;
 
-    @Override
-    public InfoQueryContractParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static InfoQueryContractParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedContractId = Optional.ofNullable((String) jrpcParams.get("contractId"));
         var parsedQueryPayment = Optional.ofNullable((String) jrpcParams.get("queryPayment"));
         var parsedMaxQueryPayment = Optional.ofNullable((String) jrpcParams.get("maxQueryPayment"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/UpdateContractParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/contract/UpdateContractParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * UpdateContractParams for contract update method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class UpdateContractParams extends JSONRPC2Param {
+public class UpdateContractParams implements JSONRPC2Param {
     private Optional<String> contractId;
     private Optional<String> adminKey;
     private Optional<String> autoRenewPeriod;
@@ -31,8 +29,7 @@ public class UpdateContractParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public UpdateContractParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static UpdateContractParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedContractId = Optional.ofNullable((String) jrpcParams.get("contractId"));
         var parsedAdminKey = Optional.ofNullable((String) jrpcParams.get("adminKey"));
         var parsedAutoRenewPeriod = Optional.ofNullable((String) jrpcParams.get("autoRenewPeriod"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/ethereum/EthereumTransactionParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/ethereum/EthereumTransactionParams.java
@@ -8,20 +8,17 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class EthereumTransactionParams extends JSONRPC2Param {
+public class EthereumTransactionParams implements JSONRPC2Param {
     private String ethereumData;
     private String callDataFileId;
     private String maxGasAllowance;
     private CommonTransactionParams commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public EthereumTransactionParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static EthereumTransactionParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedEthereumData = (String) jrpcParams.get("ethereumData");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileAppendParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileAppendParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * FileAppendParams for file append method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileAppendParams extends JSONRPC2Param {
+public class FileAppendParams implements JSONRPC2Param {
     private Optional<String> fileId;
     private Optional<String> contents;
     private Optional<Long> maxChunks;
@@ -25,8 +23,7 @@ public class FileAppendParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public FileAppendParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileAppendParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedFileId = Optional.ofNullable((String) jrpcParams.get("fileId"));
         var parsedContents = Optional.ofNullable((String) jrpcParams.get("contents"));
         var parsedMaxChunks = Optional.ofNullable((Long) jrpcParams.get("maxChunks"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileContentsParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileContentsParams.java
@@ -7,22 +7,19 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * GetFileContentsParams for get file contents method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileContentsParams extends JSONRPC2Param {
+public class FileContentsParams implements JSONRPC2Param {
     private String fileId;
     private Optional<String> queryPayment;
     private Optional<String> maxQueryPayment;
     private String sessionId;
 
-    @Override
-    public FileContentsParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileContentsParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedFileId = (String) jrpcParams.get("fileId");
         var parsedQueryPayment = Optional.ofNullable((String) jrpcParams.get("queryPayment"));
         var parsedMaxQueryPayment = Optional.ofNullable((String) jrpcParams.get("maxQueryPayment"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileCreateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileCreateParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * FileCreateParams for file create method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileCreateParams extends JSONRPC2Param {
+public class FileCreateParams implements JSONRPC2Param {
     private Optional<List<String>> keys;
     private Optional<String> contents;
     private Optional<String> expirationTime;
@@ -25,8 +23,7 @@ public class FileCreateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public FileCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedKeys = parseStringList(jrpcParams, "keys");
         var parsedContents = Optional.ofNullable((String) jrpcParams.get("contents"));
         var parsedExpirationTime = Optional.ofNullable((String) jrpcParams.get("expirationTime"));
@@ -43,7 +40,7 @@ public class FileCreateParams extends JSONRPC2Param {
     }
 
     @SuppressWarnings("unchecked")
-    private Optional<List<String>> parseStringList(Map<String, Object> params, String key) {
+    private static Optional<List<String>> parseStringList(Map<String, Object> params, String key) {
         if (!params.containsKey(key)) {
             return Optional.empty();
         }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileDeleteParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileDeleteParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * FileDeleteParams for file delete method
@@ -16,14 +15,12 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileDeleteParams extends JSONRPC2Param {
+public class FileDeleteParams implements JSONRPC2Param {
     private Optional<String> fileId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public FileDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedFileId = Optional.ofNullable((String) jrpcParams.get("fileId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileInfoQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileInfoQueryParams.java
@@ -7,19 +7,16 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileInfoQueryParams extends JSONRPC2Param {
+public class FileInfoQueryParams implements JSONRPC2Param {
     private String fileId;
     private String queryPayment;
     private String maxQueryPayment;
     private String sessionId;
 
-    @Override
-    public FileInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedFileId = (String) jrpcParams.get("fileId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileUpdateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/file/FileUpdateParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * FileUpdateParams for file update method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FileUpdateParams extends JSONRPC2Param {
+public class FileUpdateParams implements JSONRPC2Param {
     private Optional<String> fileId;
     private Optional<List<String>> keys;
     private Optional<String> contents;
@@ -26,8 +24,7 @@ public class FileUpdateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public FileUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FileUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedFileId = Optional.ofNullable((String) jrpcParams.get("fileId"));
         var parsedKeys = parseStringList(jrpcParams, "keys");
         var parsedContents = Optional.ofNullable((String) jrpcParams.get("contents"));
@@ -46,7 +43,7 @@ public class FileUpdateParams extends JSONRPC2Param {
     }
 
     @SuppressWarnings("unchecked")
-    private Optional<List<String>> parseStringList(Map<String, Object> params, String key) {
+    private static Optional<List<String>> parseStringList(Map<String, Object> params, String key) {
         if (!params.containsKey(key)) {
             return Optional.empty();
         }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/AddressBookQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/AddressBookQueryParams.java
@@ -7,18 +7,15 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AddressBookQueryParams extends JSONRPC2Param {
+public class AddressBookQueryParams implements JSONRPC2Param {
     private String fileId;
     private Long limit;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AddressBookQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedFileId = (String) jrpcParams.get("fileId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeCreateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeCreateParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class NodeCreateParams extends JSONRPC2Param {
+public class NodeCreateParams implements JSONRPC2Param {
     private Optional<String> accountId;
     private Optional<String> description;
     private Optional<List<ServiceEndpointParams>> gossipEndpoints;
@@ -30,8 +28,7 @@ public class NodeCreateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public NodeCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static NodeCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedDescription = Optional.ofNullable((String) jrpcParams.get("description"));
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeDeleteParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeDeleteParams.java
@@ -8,19 +8,16 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class NodeDeleteParams extends JSONRPC2Param {
+public class NodeDeleteParams implements JSONRPC2Param {
     private Optional<String> nodeId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public NodeDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static NodeDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedNodeId = Optional.ofNullable((String) jrpcParams.get("nodeId"));
         var parsedCommonTx = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeUpdateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/NodeUpdateParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class NodeUpdateParams extends JSONRPC2Param {
+public class NodeUpdateParams implements JSONRPC2Param {
     private Optional<String> nodeId;
     private Optional<String> accountId;
     private Optional<String> description;
@@ -31,8 +29,7 @@ public class NodeUpdateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public NodeUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static NodeUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedNodeId = Optional.ofNullable((String) jrpcParams.get("nodeId"));
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedDescription = Optional.ofNullable((String) jrpcParams.get("description"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/ServiceEndpointParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/node/ServiceEndpointParams.java
@@ -6,13 +6,11 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.bouncycastle.util.encoders.Hex;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class ServiceEndpointParams {
     private Optional<String> ipAddressV4;
     private Optional<String> domainName;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleCreateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleCreateParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * ScheduleCreateParams for schedule create method
@@ -16,8 +15,7 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ScheduleCreateParams extends JSONRPC2Param {
+public class ScheduleCreateParams implements JSONRPC2Param {
     private Optional<ScheduledTransaction> scheduledTransaction;
     private Optional<String> memo;
     private Optional<String> adminKey;
@@ -27,8 +25,7 @@ public class ScheduleCreateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public ScheduleCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ScheduleCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedScheduledTransaction = Optional.ofNullable(
                         (Map<String, Object>) jrpcParams.get("scheduledTransaction"))
                 .map(ScheduledTransaction::new);
@@ -55,7 +52,6 @@ public class ScheduleCreateParams extends JSONRPC2Param {
      */
     @Getter
     @AllArgsConstructor
-    @NoArgsConstructor
     public static class ScheduledTransaction {
         private String method;
         private Map<String, Object> params;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleDeleteParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleDeleteParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * ScheduleDeleteParams for delete schedule method
@@ -16,14 +15,12 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ScheduleDeleteParams extends JSONRPC2Param {
+public class ScheduleDeleteParams implements JSONRPC2Param {
     private Optional<String> scheduleId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public ScheduleDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ScheduleDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedScheduleId = Optional.ofNullable((String) jrpcParams.get("scheduleId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleInfoParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleInfoParams.java
@@ -7,20 +7,17 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ScheduleInfoParams extends JSONRPC2Param {
+public class ScheduleInfoParams implements JSONRPC2Param {
     private String scheduleId;
     private String queryPayment;
     private String maxQueryPayment;
     private Boolean getCost;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedScheduleId = (String) jrpcParams.get("scheduleId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleSignParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/schedule/ScheduleSignParams.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * ScheduleSignParams for sign schedule method
@@ -16,14 +15,12 @@ import lombok.NoArgsConstructor;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class ScheduleSignParams extends JSONRPC2Param {
+public class ScheduleSignParams implements JSONRPC2Param {
     private Optional<String> scheduleId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public ScheduleSignParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static ScheduleSignParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedScheduleId = Optional.ofNullable((String) jrpcParams.get("scheduleId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/AssociateDisassociateTokenParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/AssociateDisassociateTokenParams.java
@@ -9,19 +9,16 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class AssociateDisassociateTokenParams extends JSONRPC2Param {
+public class AssociateDisassociateTokenParams implements JSONRPC2Param {
     private Optional<String> accountId;
     private Optional<List<String>> tokenIds;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static AssociateDisassociateTokenParams parse(Map<String, Object> jrpcParams) throws Exception {
 
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedTokenIds = Optional.ofNullable((List<String>) jrpcParams.get("tokenIds"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/BurnTokenParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/BurnTokenParams.java
@@ -9,12 +9,10 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class BurnTokenParams extends JSONRPC2Param {
+public class BurnTokenParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<String> amount;
     private Optional<List<String>> metadata;
@@ -22,8 +20,7 @@ public class BurnTokenParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static BurnTokenParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedAmount = Optional.ofNullable((String) jrpcParams.get("amount"));
         var parsedMetadata = Optional.ofNullable((List<String>) jrpcParams.get("metadata"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/FreezeUnfreezeTokenParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/FreezeUnfreezeTokenParams.java
@@ -8,19 +8,16 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class FreezeUnfreezeTokenParams extends JSONRPC2Param {
+public class FreezeUnfreezeTokenParams implements JSONRPC2Param {
     private Optional<String> accountId;
     private Optional<String> tokenId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static FreezeUnfreezeTokenParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/GrantRevokeTokenKycParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/GrantRevokeTokenKycParams.java
@@ -8,19 +8,16 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class GrantRevokeTokenKycParams extends JSONRPC2Param {
+public class GrantRevokeTokenKycParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<String> accountId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static GrantRevokeTokenKycParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/MintTokenParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/MintTokenParams.java
@@ -9,20 +9,17 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class MintTokenParams extends JSONRPC2Param {
+public class MintTokenParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<String> amount;
     private Optional<List<String>> metadata;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static MintTokenParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedAmount = Optional.ofNullable((String) jrpcParams.get("amount"));
         var parsedMetadata = Optional.ofNullable((List<String>) jrpcParams.get("metadata"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/NftInfoQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/NftInfoQueryParams.java
@@ -6,17 +6,14 @@ import com.hedera.hashgraph.tck.util.JSONRPCParamParser;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class NftInfoQueryParams extends JSONRPC2Param {
+public class NftInfoQueryParams implements JSONRPC2Param {
     private String nftId;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static NftInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedNftId = (String) jrpcParams.get("nftId");
         return new NftInfoQueryParams(parsedNftId, JSONRPCParamParser.parseSessionId(jrpcParams));
     }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/PauseUnpauseTokenParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/PauseUnpauseTokenParams.java
@@ -8,18 +8,15 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class PauseUnpauseTokenParams extends JSONRPC2Param {
+public class PauseUnpauseTokenParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static PauseUnpauseTokenParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/PendingAirdropParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/PendingAirdropParams.java
@@ -6,11 +6,9 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class PendingAirdropParams {
     private Optional<String> tokenId;
     private Optional<String> senderAccountId;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenAirdropCancelParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenAirdropCancelParams.java
@@ -10,18 +10,15 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenAirdropCancelParams extends JSONRPC2Param {
+public class TokenAirdropCancelParams implements JSONRPC2Param {
     private Optional<List<PendingAirdropParams>> pendingAirdrops;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenAirdropCancelParams parse(Map<String, Object> jrpcParams) throws Exception {
         @SuppressWarnings("unchecked")
         var parsedPendingAirdrops = Optional.ofNullable((List<Object>) jrpcParams.get("pendingAirdrops"))
                 .map(list -> list.stream()

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenAirdropParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenAirdropParams.java
@@ -11,22 +11,19 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * TokenAirdropParams for token airdrop method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenAirdropParams extends JSONRPC2Param {
+public class TokenAirdropParams implements JSONRPC2Param {
 
     private Optional<List<TransferParams>> tokenTransfers;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenAirdropParams parse(Map<String, Object> jrpcParams) throws Exception {
         @SuppressWarnings("unchecked")
         var parsedTokenTransfers = Optional.ofNullable((List<Object>) jrpcParams.get("tokenTransfers"))
                 .map(list -> list.stream()

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenClaimAirdropParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenClaimAirdropParams.java
@@ -9,12 +9,10 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenClaimAirdropParams extends JSONRPC2Param {
+public class TokenClaimAirdropParams implements JSONRPC2Param {
     private Optional<String> senderAccountId;
     private Optional<String> receiverAccountId;
     private Optional<String> tokenId;
@@ -22,8 +20,7 @@ public class TokenClaimAirdropParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenClaimAirdropParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedSenderAccountId = Optional.ofNullable((String) jrpcParams.get("senderAccountId"));
         var parsedReceiverAccountId = Optional.ofNullable((String) jrpcParams.get("receiverAccountId"));
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenCreateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenCreateParams.java
@@ -10,15 +10,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * TokenCreateParams for token create method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenCreateParams extends JSONRPC2Param {
+public class TokenCreateParams implements JSONRPC2Param {
     private Optional<String> name;
     private Optional<String> symbol;
     private Optional<Long> decimals;
@@ -45,8 +43,7 @@ public class TokenCreateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenCreateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedName = Optional.ofNullable((String) jrpcParams.get("name"));
         var parsedSymbol = Optional.ofNullable((String) jrpcParams.get("symbol"));
         var parsedDecimals = Optional.ofNullable((Long) jrpcParams.get("decimals"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenDeleteParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenDeleteParams.java
@@ -8,21 +8,18 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * TokenDeleteParams for token delete method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenDeleteParams extends JSONRPC2Param {
+public class TokenDeleteParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenDeleteParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenInfoQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenInfoQueryParams.java
@@ -7,17 +7,14 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenInfoQueryParams extends JSONRPC2Param {
+public class TokenInfoQueryParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
 
         return new TokenInfoQueryParams(parsedTokenId, JSONRPCParamParser.parseSessionId(jrpcParams));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenRejectAirdropParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenRejectAirdropParams.java
@@ -9,20 +9,17 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenRejectAirdropParams extends JSONRPC2Param {
+public class TokenRejectAirdropParams implements JSONRPC2Param {
     private Optional<String> ownerAccountId;
     private Optional<List<String>> tokenIds;
     private Optional<List<String>> serialNumbers;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenRejectAirdropParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedOwnerAccountId = Optional.ofNullable((String) jrpcParams.get("ownerId"));
         var parsedTokenIds = Optional.ofNullable((List<String>) jrpcParams.get("tokenIds"));
         var parsedSerialNumbers = Optional.ofNullable((List<String>) jrpcParams.get("serialNumbers"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenUpdateFeeScheduleParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenUpdateFeeScheduleParams.java
@@ -10,20 +10,17 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenUpdateFeeScheduleParams extends JSONRPC2Param {
+public class TokenUpdateFeeScheduleParams implements JSONRPC2Param {
 
     private Optional<String> tokenId;
     private Optional<List<CustomFee>> customFees;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenUpdateFeeScheduleParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
 
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenUpdateParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenUpdateParams.java
@@ -8,15 +8,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * TokenUpdateParams for token update method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenUpdateParams extends JSONRPC2Param {
+public class TokenUpdateParams implements JSONRPC2Param {
     private Optional<String> tokenId;
     private Optional<String> name;
     private Optional<String> symbol;
@@ -37,8 +35,7 @@ public class TokenUpdateParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenUpdateParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedName = Optional.ofNullable((String) jrpcParams.get("name"));
         var parsedSymbol = Optional.ofNullable((String) jrpcParams.get("symbol"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenWipeParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/token/TokenWipeParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * WipeTokenParams for token wipe method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TokenWipeParams extends JSONRPC2Param {
+public class TokenWipeParams implements JSONRPC2Param {
 
     private Optional<String> tokenId;
     private Optional<String> accountId;
@@ -26,8 +24,7 @@ public class TokenWipeParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TokenWipeParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTokenId = Optional.ofNullable((String) jrpcParams.get("tokenId"));
         var parsedAccountId = Optional.ofNullable((String) jrpcParams.get("accountId"));
         var parsedAmount = Optional.ofNullable((String) jrpcParams.get("amount"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/CreateTopicParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/CreateTopicParams.java
@@ -10,15 +10,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * CreateTopicParams for topic create method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class CreateTopicParams extends JSONRPC2Param {
+public class CreateTopicParams implements JSONRPC2Param {
     private Optional<String> memo;
     private Optional<String> adminKey;
     private Optional<String> submitKey;
@@ -30,8 +28,7 @@ public class CreateTopicParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static CreateTopicParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedMemo = Optional.ofNullable((String) jrpcParams.get("memo"));
         var parsedAdminKey = Optional.ofNullable((String) jrpcParams.get("adminKey"));
         var parsedSubmitKey = Optional.ofNullable((String) jrpcParams.get("submitKey"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/CustomFeeLimit.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/CustomFeeLimit.java
@@ -8,20 +8,17 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * CustomFeeLimit for topic message submit method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class CustomFeeLimit extends JSONRPC2Param {
+public class CustomFeeLimit implements JSONRPC2Param {
     private Optional<String> payerId;
     private Optional<List<CustomFee.FixedFee>> fixedFees;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static CustomFeeLimit parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedPayerId = Optional.ofNullable((String) jrpcParams.get("payerId"));
 
         @SuppressWarnings("unchecked")

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/DeleteTopicParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/DeleteTopicParams.java
@@ -8,21 +8,18 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * DeleteTopicParams for topic delete method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class DeleteTopicParams extends JSONRPC2Param {
+public class DeleteTopicParams implements JSONRPC2Param {
     private Optional<String> topicId;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static DeleteTopicParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTopicId = Optional.ofNullable((String) jrpcParams.get("topicId"));
         var parsedCommonTransactionParams = JSONRPCParamParser.parseCommonTransactionParams(jrpcParams);
 

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/SubmitTopicMessageParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/SubmitTopicMessageParams.java
@@ -9,15 +9,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * SubmitTopicMessageParams for topic message submit method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class SubmitTopicMessageParams extends JSONRPC2Param {
+public class SubmitTopicMessageParams implements JSONRPC2Param {
     private Optional<String> topicId;
     private Optional<String> message;
     private Optional<Long> maxChunks;
@@ -26,8 +24,7 @@ public class SubmitTopicMessageParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static SubmitTopicMessageParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTopicId = Optional.ofNullable((String) jrpcParams.get("topicId"));
         var parsedMessage = Optional.ofNullable((String) jrpcParams.get("message"));
         var parsedMaxChunks = Optional.ofNullable((Long) jrpcParams.get("maxChunks"));
@@ -41,7 +38,7 @@ public class SubmitTopicMessageParams extends JSONRPC2Param {
             var customFeeLimits = customFeeLimitsList.stream()
                     .map(customFeeLimitMap -> {
                         try {
-                            return (CustomFeeLimit) new CustomFeeLimit().parse(customFeeLimitMap);
+                            return CustomFeeLimit.parse(customFeeLimitMap);
                         } catch (Exception e) {
                             throw new RuntimeException("Failed to parse custom fee limit", e);
                         }

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/TopicInfoQueryParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/TopicInfoQueryParams.java
@@ -7,19 +7,16 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TopicInfoQueryParams extends JSONRPC2Param {
+public class TopicInfoQueryParams implements JSONRPC2Param {
     private String topicId;
     private String queryPayment;
     private String maxQueryPayment;
     private String sessionId;
 
-    @Override
-    public TopicInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TopicInfoQueryParams parse(Map<String, Object> jrpcParams) throws Exception {
         Objects.requireNonNull(jrpcParams, "jrpcParams must not be null");
 
         var parsedTopicId = (String) jrpcParams.get("topicId");

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/UpdateTopicParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/topic/UpdateTopicParams.java
@@ -10,15 +10,13 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * UpdateTopicParams for topic update method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class UpdateTopicParams extends JSONRPC2Param {
+public class UpdateTopicParams implements JSONRPC2Param {
     private Optional<String> topicId;
     private Optional<String> memo;
     private Optional<String> adminKey;
@@ -32,8 +30,7 @@ public class UpdateTopicParams extends JSONRPC2Param {
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static UpdateTopicParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTopicId = Optional.ofNullable((String) jrpcParams.get("topicId"));
         var parsedMemo = Optional.ofNullable((String) jrpcParams.get("memo"));
         var parsedAdminKey = Optional.ofNullable((String) jrpcParams.get("adminKey"));

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/HbarTransferParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/HbarTransferParams.java
@@ -5,14 +5,12 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * Contains the parameters of a Hbar transfer.
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class HbarTransferParams {
     private Optional<String> accountId;
     private Optional<String> evmAddress;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/NftTransferParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/NftTransferParams.java
@@ -5,14 +5,12 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * Contains the parameters of an NFT transfer.
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class NftTransferParams {
     private Optional<String> senderAccountId;
     private Optional<String> receiverAccountId;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TokenTransferParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TokenTransferParams.java
@@ -5,14 +5,12 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * Contains the parameters of a token transfer.
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class TokenTransferParams {
     private Optional<String> accountId;
     private Optional<String> tokenId;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TransferCryptoParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TransferCryptoParams.java
@@ -9,21 +9,18 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * TransferCryptoParams for transfer crypto method
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
-public class TransferCryptoParams extends JSONRPC2Param {
+public class TransferCryptoParams implements JSONRPC2Param {
     private Optional<List<TransferParams>> transfers;
     private Optional<CommonTransactionParams> commonTransactionParams;
     private String sessionId;
 
-    @Override
-    public JSONRPC2Param parse(Map<String, Object> jrpcParams) throws Exception {
+    public static TransferCryptoParams parse(Map<String, Object> jrpcParams) throws Exception {
         var parsedTransfers = Optional.ofNullable(jrpcParams.get("transfers"))
                 .filter(obj -> obj instanceof List)
                 .map(obj -> {

--- a/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TransferParams.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/methods/sdk/param/transfer/TransferParams.java
@@ -5,14 +5,12 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * Contains the parameters of a transfer.
  */
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class TransferParams {
     private Optional<HbarTransferParams> hbar;
     private Optional<TokenTransferParams> token;

--- a/tck/src/main/java/com/hedera/hashgraph/tck/util/JSONRPCParamParser.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/util/JSONRPCParamParser.java
@@ -31,7 +31,7 @@ public class JSONRPCParamParser {
     }
 
     public static Optional<List<CustomFee>> parseCustomFees(Map<String, Object> jrpcParams) throws Exception {
-        return parseJsonArray(jrpcParams, "customFees", jsonObj -> new CustomFee().parse(jsonObj));
+        return parseJsonArray(jrpcParams, "customFees", jsonObj -> CustomFee.parse(jsonObj));
     }
 
     private static <T> Optional<T> parseJsonObject(

--- a/tck/src/main/java/com/hedera/hashgraph/tck/util/TransactionBuilders.java
+++ b/tck/src/main/java/com/hedera/hashgraph/tck/util/TransactionBuilders.java
@@ -146,7 +146,7 @@ public class TransactionBuilders {
 
         public static AccountCreateTransaction buildCreate(Map<String, Object> params) {
             try {
-                AccountCreateParams typedParams = new AccountCreateParams().parse(params);
+                AccountCreateParams typedParams = AccountCreateParams.parse(params);
                 return buildCreate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AccountCreateParams", e);
@@ -197,7 +197,7 @@ public class TransactionBuilders {
 
         public static AccountUpdateTransaction buildUpdate(Map<String, Object> params) {
             try {
-                AccountUpdateParams typedParams = new AccountUpdateParams().parse(params);
+                AccountUpdateParams typedParams = AccountUpdateParams.parse(params);
                 return buildUpdate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AccountUpdateParams", e);
@@ -219,7 +219,7 @@ public class TransactionBuilders {
 
         public static AccountDeleteTransaction buildDelete(Map<String, Object> params) {
             try {
-                AccountDeleteParams typedParams = new AccountDeleteParams().parse(params);
+                AccountDeleteParams typedParams = AccountDeleteParams.parse(params);
                 return buildDelete(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AccountDeleteParams", e);
@@ -238,8 +238,7 @@ public class TransactionBuilders {
 
         public static AccountAllowanceApproveTransaction buildApproveAllowance(Map<String, Object> params) {
             try {
-                AccountAllowanceParams typedParams =
-                        (AccountAllowanceParams) new AccountAllowanceParams().parse(params);
+                AccountAllowanceParams typedParams = AccountAllowanceParams.parse(params);
                 return buildApproveAllowance(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AccountAllowanceParams", e);
@@ -258,8 +257,7 @@ public class TransactionBuilders {
 
         public static AccountAllowanceDeleteTransaction buildDeleteAllowance(Map<String, Object> params) {
             try {
-                AccountAllowanceParams typedParams =
-                        (AccountAllowanceParams) new AccountAllowanceParams().parse(params);
+                AccountAllowanceParams typedParams = AccountAllowanceParams.parse(params);
                 return buildDeleteAllowance(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AccountAllowanceParams", e);
@@ -340,7 +338,7 @@ public class TransactionBuilders {
 
         public static TransferTransaction buildTransfer(Map<String, Object> params) {
             try {
-                TransferCryptoParams typedParams = (TransferCryptoParams) new TransferCryptoParams().parse(params);
+                TransferCryptoParams typedParams = TransferCryptoParams.parse(params);
                 return buildTransfer(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TransferCryptoParams", e);
@@ -444,7 +442,7 @@ public class TransactionBuilders {
 
         public static TokenCreateTransaction buildCreate(Map<String, Object> params) {
             try {
-                TokenCreateParams typedParams = (TokenCreateParams) new TokenCreateParams().parse(params);
+                TokenCreateParams typedParams = TokenCreateParams.parse(params);
                 return buildCreate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenCreateParams", e);
@@ -547,7 +545,7 @@ public class TransactionBuilders {
 
         public static TokenUpdateTransaction buildUpdate(Map<String, Object> params) {
             try {
-                TokenUpdateParams typedParams = (TokenUpdateParams) new TokenUpdateParams().parse(params);
+                TokenUpdateParams typedParams = TokenUpdateParams.parse(params);
                 return buildUpdate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenUpdateParams", e);
@@ -564,7 +562,7 @@ public class TransactionBuilders {
 
         public static TokenDeleteTransaction buildDelete(Map<String, Object> params) {
             try {
-                TokenDeleteParams typedParams = (TokenDeleteParams) new TokenDeleteParams().parse(params);
+                TokenDeleteParams typedParams = TokenDeleteParams.parse(params);
                 return buildDelete(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenDeleteParams", e);
@@ -591,7 +589,7 @@ public class TransactionBuilders {
 
         public static TokenMintTransaction buildMint(Map<String, Object> params) {
             try {
-                MintTokenParams typedParams = (MintTokenParams) new MintTokenParams().parse(params);
+                MintTokenParams typedParams = MintTokenParams.parse(params);
                 return buildMint(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse MintTokenParams", e);
@@ -620,7 +618,7 @@ public class TransactionBuilders {
 
         public static TokenBurnTransaction buildBurn(Map<String, Object> params) {
             try {
-                BurnTokenParams typedParams = (BurnTokenParams) new BurnTokenParams().parse(params);
+                BurnTokenParams typedParams = BurnTokenParams.parse(params);
                 return buildBurn(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse BurnTokenParams", e);
@@ -653,7 +651,7 @@ public class TransactionBuilders {
 
         public static TokenWipeTransaction buildWipe(Map<String, Object> params) {
             try {
-                TokenWipeParams typedParams = (TokenWipeParams) new TokenWipeParams().parse(params);
+                TokenWipeParams typedParams = TokenWipeParams.parse(params);
                 return buildWipe(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenWipeParams", e);
@@ -663,8 +661,7 @@ public class TransactionBuilders {
         // Additional token operations for schedule support
         public static TokenAssociateTransaction buildAssociate(Map<String, Object> params) {
             try {
-                AssociateDisassociateTokenParams typedParams =
-                        (AssociateDisassociateTokenParams) new AssociateDisassociateTokenParams().parse(params);
+                AssociateDisassociateTokenParams typedParams = AssociateDisassociateTokenParams.parse(params);
                 return buildAssociate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AssociateDisassociateTokenParams", e);
@@ -687,8 +684,7 @@ public class TransactionBuilders {
 
         public static TokenDissociateTransaction buildDissociate(Map<String, Object> params) {
             try {
-                AssociateDisassociateTokenParams typedParams =
-                        (AssociateDisassociateTokenParams) new AssociateDisassociateTokenParams().parse(params);
+                AssociateDisassociateTokenParams typedParams = AssociateDisassociateTokenParams.parse(params);
                 return buildDissociate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse AssociateDisassociateTokenParams", e);
@@ -711,8 +707,7 @@ public class TransactionBuilders {
 
         public static TokenFreezeTransaction buildFreeze(Map<String, Object> params) {
             try {
-                FreezeUnfreezeTokenParams typedParams =
-                        (FreezeUnfreezeTokenParams) new FreezeUnfreezeTokenParams().parse(params);
+                FreezeUnfreezeTokenParams typedParams = FreezeUnfreezeTokenParams.parse(params);
                 return buildFreeze(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FreezeUnfreezeTokenParams", e);
@@ -730,8 +725,7 @@ public class TransactionBuilders {
 
         public static TokenUnfreezeTransaction buildUnfreeze(Map<String, Object> params) {
             try {
-                FreezeUnfreezeTokenParams typedParams =
-                        (FreezeUnfreezeTokenParams) new FreezeUnfreezeTokenParams().parse(params);
+                FreezeUnfreezeTokenParams typedParams = FreezeUnfreezeTokenParams.parse(params);
                 return buildUnfreeze(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FreezeUnfreezeTokenParams", e);
@@ -750,8 +744,7 @@ public class TransactionBuilders {
 
         public static TokenGrantKycTransaction buildGrantKyc(Map<String, Object> params) {
             try {
-                GrantRevokeTokenKycParams typedParams =
-                        (GrantRevokeTokenKycParams) new GrantRevokeTokenKycParams().parse(params);
+                GrantRevokeTokenKycParams typedParams = GrantRevokeTokenKycParams.parse(params);
                 return buildGrantKyc(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse GrantRevokeTokenKycParams", e);
@@ -770,8 +763,7 @@ public class TransactionBuilders {
 
         public static TokenRevokeKycTransaction buildRevokeKyc(Map<String, Object> params) {
             try {
-                GrantRevokeTokenKycParams typedParams =
-                        (GrantRevokeTokenKycParams) new GrantRevokeTokenKycParams().parse(params);
+                GrantRevokeTokenKycParams typedParams = GrantRevokeTokenKycParams.parse(params);
                 return buildRevokeKyc(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse GrantRevokeTokenKycParams", e);
@@ -790,8 +782,7 @@ public class TransactionBuilders {
 
         public static TokenPauseTransaction buildPause(Map<String, Object> params) {
             try {
-                PauseUnpauseTokenParams typedParams =
-                        (PauseUnpauseTokenParams) new PauseUnpauseTokenParams().parse(params);
+                PauseUnpauseTokenParams typedParams = PauseUnpauseTokenParams.parse(params);
                 return buildPause(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse PauseUnpauseTokenParams", e);
@@ -808,8 +799,7 @@ public class TransactionBuilders {
 
         public static TokenUnpauseTransaction buildUnpause(Map<String, Object> params) {
             try {
-                PauseUnpauseTokenParams typedParams =
-                        (PauseUnpauseTokenParams) new PauseUnpauseTokenParams().parse(params);
+                PauseUnpauseTokenParams typedParams = PauseUnpauseTokenParams.parse(params);
                 return buildUnpause(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse PauseUnpauseTokenParams", e);
@@ -843,8 +833,7 @@ public class TransactionBuilders {
 
         public static TokenFeeScheduleUpdateTransaction buildUpdateFeeSchedule(Map<String, Object> params) {
             try {
-                TokenUpdateFeeScheduleParams typedParams =
-                        (TokenUpdateFeeScheduleParams) new TokenUpdateFeeScheduleParams().parse(params);
+                TokenUpdateFeeScheduleParams typedParams = TokenUpdateFeeScheduleParams.parse(params);
                 return buildUpdateFeeSchedule(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenUpdateFeeScheduleParams", e);
@@ -870,7 +859,7 @@ public class TransactionBuilders {
 
         public static TokenAirdropTransaction buildAirdrop(Map<String, Object> params) {
             try {
-                TokenAirdropParams typedParams = (TokenAirdropParams) new TokenAirdropParams().parse(params);
+                TokenAirdropParams typedParams = TokenAirdropParams.parse(params);
                 return buildAirdrop(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenAirdropParams", e);
@@ -916,8 +905,7 @@ public class TransactionBuilders {
 
         public static TokenCancelAirdropTransaction buildCancelAirdrop(Map<String, Object> params) {
             try {
-                TokenAirdropCancelParams typedParams =
-                        (TokenAirdropCancelParams) new TokenAirdropCancelParams().parse(params);
+                TokenAirdropCancelParams typedParams = TokenAirdropCancelParams.parse(params);
                 return buildCancelAirdrop(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenAirdropCancelParams", e);
@@ -981,8 +969,7 @@ public class TransactionBuilders {
 
         public static TokenClaimAirdropTransaction buildClaimAirdrop(Map<String, Object> params) {
             try {
-                TokenClaimAirdropParams typedParams =
-                        (TokenClaimAirdropParams) new TokenClaimAirdropParams().parse(params);
+                TokenClaimAirdropParams typedParams = TokenClaimAirdropParams.parse(params);
                 return buildClaimAirdrop(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse TokenClaimAirdropParams", e);
@@ -1141,7 +1128,7 @@ public class TransactionBuilders {
 
         public static TopicCreateTransaction buildCreate(Map<String, Object> params) {
             try {
-                CreateTopicParams typedParams = (CreateTopicParams) new CreateTopicParams().parse(params);
+                CreateTopicParams typedParams = CreateTopicParams.parse(params);
                 return buildCreate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse CreateTopicParams", e);
@@ -1178,7 +1165,7 @@ public class TransactionBuilders {
 
         public static TopicUpdateTransaction buildUpdate(Map<String, Object> params) {
             try {
-                UpdateTopicParams typedParams = (UpdateTopicParams) new UpdateTopicParams().parse(params);
+                UpdateTopicParams typedParams = UpdateTopicParams.parse(params);
                 return buildUpdate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse UpdateTopicParams", e);
@@ -1201,7 +1188,7 @@ public class TransactionBuilders {
 
         public static TopicDeleteTransaction buildDelete(Map<String, Object> params) {
             try {
-                DeleteTopicParams typedParams = (DeleteTopicParams) new DeleteTopicParams().parse(params);
+                DeleteTopicParams typedParams = DeleteTopicParams.parse(params);
                 return buildDelete(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse DeleteTopicParams", e);
@@ -1287,8 +1274,7 @@ public class TransactionBuilders {
 
         public static TopicMessageSubmitTransaction buildSubmitMessage(Map<String, Object> params) {
             try {
-                SubmitTopicMessageParams typedParams =
-                        (SubmitTopicMessageParams) new SubmitTopicMessageParams().parse(params);
+                SubmitTopicMessageParams typedParams = SubmitTopicMessageParams.parse(params);
                 return buildSubmitMessage(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse SubmitTopicMessageParams", e);
@@ -1330,7 +1316,7 @@ public class TransactionBuilders {
 
         public static FileCreateTransaction buildCreate(Map<String, Object> params) {
             try {
-                FileCreateParams typedParams = new FileCreateParams().parse(params);
+                FileCreateParams typedParams = FileCreateParams.parse(params);
                 return buildCreate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FileCreateParams", e);
@@ -1367,7 +1353,7 @@ public class TransactionBuilders {
 
         public static FileUpdateTransaction buildUpdate(Map<String, Object> params) {
             try {
-                FileUpdateParams typedParams = new FileUpdateParams().parse(params);
+                FileUpdateParams typedParams = FileUpdateParams.parse(params);
                 return buildUpdate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FileUpdateParams", e);
@@ -1384,7 +1370,7 @@ public class TransactionBuilders {
 
         public static FileDeleteTransaction buildDelete(Map<String, Object> params) {
             try {
-                FileDeleteParams typedParams = new FileDeleteParams().parse(params);
+                FileDeleteParams typedParams = FileDeleteParams.parse(params);
                 return buildDelete(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FileDeleteParams", e);
@@ -1411,7 +1397,7 @@ public class TransactionBuilders {
 
         public static FileAppendTransaction buildAppend(Map<String, Object> params) {
             try {
-                FileAppendParams typedParams = new FileAppendParams().parse(params);
+                FileAppendParams typedParams = FileAppendParams.parse(params);
                 return buildAppend(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse FileAppendParams", e);
@@ -1425,7 +1411,7 @@ public class TransactionBuilders {
     public static class EthereumBuilder {
         public static EthereumTransaction buildCreate(Map<String, Object> params) {
             try {
-                EthereumTransactionParams typedParams = new EthereumTransactionParams().parse(params);
+                EthereumTransactionParams typedParams = EthereumTransactionParams.parse(params);
                 return buildCreate(typedParams);
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to parse EthereumTransactionParam", e);

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamsRegistryTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/JSONRPC2ParamsRegistryTest.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.hashgraph.tck.methods;
+
+import static java.util.Map.entry;
+
+import com.hedera.hashgraph.tck.exception.InvalidJSONRPC2ParamsException;
+import com.hedera.hashgraph.tck.methods.sdk.param.account.AccountCreateParams;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JSONRPC2ParamsRegistryTest {
+    @Test
+    void shouldParseValidJsonRpcRequestParams() {
+        var requestParams = Map.<String, Object>ofEntries(
+                entry(
+                        "key",
+                        "3030020100300706052b8104000a04220420f3b15203915311707e26650764f8bb654bd30783fb144011ec8ccd4444a63a15"),
+                entry("initialBalance", "100"),
+                entry("receiverSignatureRequired", true),
+                entry("autoRenewPeriod", "1787170588.538185104"),
+                entry("memo", "Test"),
+                entry("maxAutoTokenAssociations", 1L),
+                entry("stakedAccountId", "0.0.2"),
+                entry("stakedNodeId", "1"),
+                entry("declineStakingReward", true),
+                entry("alias", "0x00000000000000000000000000"),
+                entry("sessionId", "101"));
+
+        var result = Assertions.assertDoesNotThrow(
+                () -> JSONRPC2ParamRegistry.parse(AccountCreateParams.class, requestParams));
+        Assertions.assertNotNull(result);
+        Assertions.assertInstanceOf(AccountCreateParams.class, result);
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidJsonRpcRequestParams() {
+        var requestParams = Map.<String, Object>ofEntries(
+                entry("initialBalance", "100"),
+                entry("receiverSignatureRequired", "true"),
+                entry("autoRenewPeriod", "1787170588.538185104"),
+                entry("memo", 9L),
+                entry("maxAutoTokenAssociations", 1),
+                entry("stakedAccountId", "0.0.2"));
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> JSONRPC2ParamRegistry.parse(AccountCreateParams.class, requestParams));
+    }
+
+    @Test
+    void shouldThrowExceptionIfJsonParamsClassNotRegister() {
+        var requestParams = Map.<String, Object>of("id", "101");
+        Assertions.assertThrows(
+                InvalidJSONRPC2ParamsException.class,
+                () -> JSONRPC2ParamRegistry.parse(MockParam.class, requestParams));
+    }
+
+    /**
+     * Helper class for test
+     */
+    private static class MockParam {
+        String id;
+
+        public MockParam(String id) {
+            this.id = id;
+        }
+    }
+}

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/AccountCreateParamsTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/AccountCreateParamsTest.java
@@ -43,7 +43,7 @@ class AccountCreateParamsTest {
 
         jrpcParams.put("commonTransactionParams", commonParamsJson);
 
-        AccountCreateParams params = new AccountCreateParams().parse(jrpcParams);
+        AccountCreateParams params = AccountCreateParams.parse(jrpcParams);
 
         assertEquals(Optional.of("someKey"), params.getKey());
         assertEquals(Optional.of("1000"), params.getInitialBalance());
@@ -77,7 +77,7 @@ class AccountCreateParamsTest {
         jrpcParams.put("key", "someKey");
         jrpcParams.put("sessionId", "session-optional");
 
-        AccountCreateParams params = new AccountCreateParams().parse(jrpcParams);
+        AccountCreateParams params = AccountCreateParams.parse(jrpcParams);
 
         assertEquals(Optional.of("someKey"), params.getKey());
         assertEquals(Optional.empty(), params.getInitialBalance());
@@ -99,7 +99,7 @@ class AccountCreateParamsTest {
         jrpcParams.put("sessionId", "session-invalid");
 
         assertThrows(ClassCastException.class, () -> {
-            new AccountCreateParams().parse(jrpcParams);
+            AccountCreateParams.parse(jrpcParams);
         });
     }
 
@@ -108,7 +108,7 @@ class AccountCreateParamsTest {
         Map<String, Object> jrpcParams = new HashMap<>();
         jrpcParams.put("sessionId", "session-empty");
 
-        AccountCreateParams params = new AccountCreateParams().parse(jrpcParams);
+        AccountCreateParams params = AccountCreateParams.parse(jrpcParams);
 
         assertEquals(Optional.empty(), params.getKey());
         assertEquals(Optional.empty(), params.getInitialBalance());

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/GenerateKeyParamsTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/GenerateKeyParamsTest.java
@@ -25,7 +25,7 @@ class GenerateKeyParamsTest {
         jsonArray.add(new JSONObject(nestedParamsMap));
         jrpcParams.put("keys", jsonArray);
 
-        GenerateKeyParams params = new GenerateKeyParams().parse(jrpcParams);
+        GenerateKeyParams params = GenerateKeyParams.parse(jrpcParams);
 
         assertEquals(KeyType.ED25519_PUBLIC_KEY, params.getType());
         assertEquals(Optional.of("someFromKey"), params.getFromKey());
@@ -42,7 +42,7 @@ class GenerateKeyParamsTest {
         Map<String, Object> jrpcParams = new HashMap<>();
         jrpcParams.put("type", "ed25519PublicKey");
 
-        GenerateKeyParams params = new GenerateKeyParams().parse(jrpcParams);
+        GenerateKeyParams params = GenerateKeyParams.parse(jrpcParams);
 
         assertEquals(KeyType.ED25519_PUBLIC_KEY, params.getType());
         assertEquals(Optional.empty(), params.getFromKey());
@@ -56,7 +56,7 @@ class GenerateKeyParamsTest {
         jrpcParams.put("type", 123); // Invalid type
 
         assertThrows(ClassCastException.class, () -> {
-            new GenerateKeyParams().parse(jrpcParams);
+            GenerateKeyParams.parse(jrpcParams);
         });
     }
 
@@ -65,7 +65,7 @@ class GenerateKeyParamsTest {
         Map<String, Object> jrpcParams = new HashMap<>();
         jrpcParams.put("type", "keyList");
 
-        GenerateKeyParams params = new GenerateKeyParams().parse(jrpcParams);
+        GenerateKeyParams params = GenerateKeyParams.parse(jrpcParams);
 
         assertEquals(Optional.empty(), params.getFromKey());
         assertEquals(Optional.empty(), params.getThreshold());
@@ -86,7 +86,7 @@ class GenerateKeyParamsTest {
         jsonArray.add(new JSONObject(nestedParamsMap2));
         jrpcParams.put("keys", jsonArray);
 
-        GenerateKeyParams params = new GenerateKeyParams().parse(jrpcParams);
+        GenerateKeyParams params = GenerateKeyParams.parse(jrpcParams);
 
         assertEquals(KeyType.LIST_KEY, params.getType());
         assertTrue(params.getKeys().isPresent());

--- a/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/SetupParamsTest.java
+++ b/tck/src/test/java/com/hedera/hashgraph/tck/methods/sdk/param/SetupParamsTest.java
@@ -22,7 +22,7 @@ class SetupParamsTest {
         jrpcParams.put("sessionId", "session-setup");
 
         // When
-        SetupParams result = new SetupParams().parse(jrpcParams);
+        SetupParams result = SetupParams.parse(jrpcParams);
 
         // Then
         assertEquals("testAccountId", result.getOperatorAccountId());


### PR DESCRIPTION
**Description**:
This PR replace the no-args instantiation of JSON-RPC params to use the typed registry.

**Changes Made:**
- Update the `JSONRPC2Param` abstract class to the marker interface as describe in the issue
- Remove the @NoArgsConstructor
- Change  `parse()` method in the request classes to static one
- Created a `JSONRPC2ParamRegistry`

**Related issue(s)**:

Fixes #2892

**Notes for reviewer**:
- Keep the registry manually maintained rather than dynamically populated. since the issue aims to eliminate reflection, happy to make it dynamic if needed :)
- Test the changes against hiero-sdk-tck using solo version `0.87.1`
<img width="1880" height="323" alt="Screenshot From 2026-09-04 18-48-12" src="https://github.com/user-attachments/assets/a8d19e51-ad5a-49ce-8b98-6c7f57090095" />



**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
